### PR TITLE
Add messaging infrastructure with RabbitMQ and Azure Service Bus support

### DIFF
--- a/Api.Project.Template.slnx
+++ b/Api.Project.Template.slnx
@@ -11,6 +11,7 @@
     <Project Path="src/Api.Project.Template.Domain/Api.Project.Template.Domain.csproj" />
     <Project Path="src/Api.Project.Template.Infrastructure/Api.Project.Template.Infrastructure.csproj" Id="599fb0ef-433a-4984-b541-1a2dfe81cee5" />
     <Project Path="src/Api.Project.Template.ServiceDefaults/Api.Project.Template.ServiceDefaults.csproj" />
+    <Project Path="src/Api.Project.Template.Worker/Api.Project.Template.Worker.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/Api.Project.Template.Tests.Architecture/Api.Project.Template.Tests.Architecture.csproj" Id="21f69fb6-32cb-4c08-964f-96e91791c92f" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,10 +5,13 @@
   <ItemGroup>
     <!-- Aspire -->
     <PackageVersion Include="Ardalis.Specification.EntityFrameworkCore" Version="9.3.1" />
+    <PackageVersion Include="Aspire.Hosting.Azure.ServiceBus" Version="13.2.1" />
     <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.2.1" />
+    <PackageVersion Include="Aspire.Hosting.RabbitMQ" Version="13.2.1" />
     <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.2.1" />
     <PackageVersion Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.2.1" />
     <PackageVersion Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="13.2.1" />
+    <PackageVersion Include="Aspire.RabbitMQ.Client" Version="13.2.1" />
     <!-- API -->
     <PackageVersion Include="Ardalis.Specification" Version="9.3.1" />
     <PackageVersion Include="AspNetCore.HealthChecks.Npgsql" Version="9.0.0" />
@@ -19,11 +22,20 @@
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
     <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />
     <PackageVersion Include="Scalar.AspNetCore" Version="2.13.20" />
+    <!-- Messaging -->
+    <PackageVersion Include="RabbitMQ.Client" Version="7.2.0" />
+    <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <!-- Tests -->
-<PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
     <PackageVersion Include="FluentAssertions" Version="8.9.0" />

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A production-ready template for building .NET Web API projects following Clean A
 - [Getting Started](#getting-started)
 - [Running the Application](#running-the-application)
 - [Database](#database)
+- [Messaging](#messaging)
 - [Solution Structure](#solution-structure)
 - [Architecture](#architecture)
 - [Patterns and Practices](#patterns-and-practices)
@@ -116,6 +117,95 @@ From this point forward, schema changes are made by adding new migrations rather
 
 ---
 
+## Messaging
+
+Messaging is provider-switchable via the `MessagingProvider` setting, following the same pattern as `DatabaseProvider`. Set it in `src/Api.Project.Template.AppHost/appsettings.json`:
+
+| Value | Broker | Infrastructure |
+|---|---|---|
+| `None` | Disabled | No broker started or registered |
+| `RabbitMq` | RabbitMQ | Docker container via Aspire, management UI at port 15672 |
+| `ServiceBus` | Azure Service Bus | Azure resource provisioned via Aspire |
+
+```json
+{
+  "MessagingProvider": "RabbitMq"
+}
+```
+
+Changing this single value in AppHost `appsettings.json` switches the broker for all projects (API and Worker). The same setting is passed to each project as an environment variable by the Aspire orchestrator.
+
+### Architecture
+
+The message bus abstraction spans three layers:
+
+- **Application** — `IMessagePublisher`, `IMessageProcessor<T>`, `MessageProcessingResult`, `MessageContext` — no broker details
+- **Infrastructure** — `RabbitMqMessagePublisher`, `ServiceBusMessagePublisher`, `RoutingMessagePublisher` (decorator), broker adapters, `MessageConsumerWorker<TMessage, TProcessor>` — all broker details live here
+- **Worker** — `WeatherRequestProcessor`, `Worker` — consumes messages; depends only on Application abstractions
+
+### Publishing — Domain Events via MediatR
+
+Messages are published from the Application layer using the **domain event pattern**:
+
+1. A MediatR handler raises an `INotification` after completing its use case
+2. An `INotificationHandler<T>` receives it and calls `IMessagePublisher.PublishAsync`
+3. `RoutingMessagePublisher` resolves the destination from `MessageBus:Routing:Routes` config and delegates to the active broker publisher
+
+```
+Handler → IPublisher.Publish(WeatherForecastRequestedEvent)
+        → WeatherForecastRequestedEventHandler
+        → IMessagePublisher.PublishAsync
+        → RoutingMessagePublisher → RabbitMqMessagePublisher / ServiceBusMessagePublisher
+```
+
+### Routing Configuration
+
+Routes are configured per message type in `appsettings.json`. The key is `typeof(T).Name` of the published event. Both `RoutingKey` (RabbitMQ) and `Subject` (Service Bus) coexist so you can switch providers without changing config:
+
+```json
+"MessageBus": {
+  "Routing": {
+    "Provider": "Auto",
+    "DefaultDestination": "weather-requests",
+    "Routes": {
+      "WeatherForecastRequestedEvent": {
+        "Destination": "weather-requests",
+        "RoutingKey": "WeatherRequested",
+        "Subject": "WeatherRequested"
+      }
+    }
+  }
+}
+```
+
+### Consuming — Worker Service
+
+`Api.Project.Template.Worker` is a .NET Worker Service that runs alongside the API. Each consumer is registered with `AddMessageConsumer<TMessage, TProcessor, TWorker>()`:
+
+- **`WeatherRequested`** — message shape, must match the serialized form of the published event
+- **`WeatherRequestProcessor`** — implements `IMessageProcessor<WeatherRequested>`, returns `MessageProcessingResult.Succeeded()` / `Failed(reason, requeue)` to control ACK/NACK/dead-letter behavior
+- **`Worker`** — named `BackgroundService` subclass of `MessageConsumerWorker<TMessage, TProcessor>`
+
+Consumer queue and broker-specific settings live in the Worker's `appsettings.json`:
+
+```json
+"MessageBus": {
+  "Consumer": {
+    "Queue": "weather-requests",
+    "Concurrency": 5,
+    "MaxRetries": 3,
+    "PrefetchCount": 10
+  },
+  "RabbitMq": {
+    "Exchange": "apiprojecttemplate.events",
+    "RoutingKey": "WeatherRequested",
+    "ExchangeType": "topic"
+  }
+}
+```
+
+---
+
 ## Solution Structure
 
 ```
@@ -123,7 +213,8 @@ src/
 ├── Api.Project.Template.Api            # Entry point — controllers, middleware, config
 ├── Api.Project.Template.Application    # Business logic — CQRS, services, abstractions
 ├── Api.Project.Template.Domain         # Core — entities, domain rules, value objects
-├── Api.Project.Template.Infrastructure # Data access — EF Core, repositories, logging
+├── Api.Project.Template.Infrastructure # Data access, messaging — EF Core, repositories, broker adapters
+├── Api.Project.Template.Worker         # Background worker — message consumers
 ├── Api.Project.Template.AppHost        # .NET Aspire orchestrator
 └── Api.Project.Template.ServiceDefaults # Shared Aspire configuration
 
@@ -426,6 +517,11 @@ The [Richardson Maturity Model](https://martinfowler.com/articles/richardsonMatu
 - [x] Entity Framework Core
   - [x] with SQL Server
   - [x] with PostgreSQL
+- [x] Messaging (provider-switchable via `MessagingProvider`)
+  - [x] RabbitMQ
+  - [x] Azure Service Bus
+  - [x] Domain event pattern (MediatR notifications → message bus)
+  - [x] Worker Service consumer (`Api.Project.Template.Worker`)
 - [x] Specifications (Ardalis.Specification)
 - [x] Seed data
 - [x] Structured logging with Serilog

--- a/src/Api.Project.Template.Api/Config/MessagingConfig.cs
+++ b/src/Api.Project.Template.Api/Config/MessagingConfig.cs
@@ -1,0 +1,16 @@
+using Api.Project.Template.Infrastructure.Messaging;
+
+namespace Api.Project.Template.Api.Config;
+
+public static class MessagingConfig
+{
+    public static void AddRabbitMqMessageBus(this IHostApplicationBuilder builder)
+    {
+        builder.Services.AddMessageBus(builder.Configuration);
+    }
+
+    public static void AddServiceBusMessageBus(this IHostApplicationBuilder builder)
+    {
+        builder.Services.AddMessageBus(builder.Configuration);
+    }
+}

--- a/src/Api.Project.Template.Api/Program.cs
+++ b/src/Api.Project.Template.Api/Program.cs
@@ -38,6 +38,13 @@ public class Program
             else
                 builder.AddSqlServerDatabaseContext();
 
+            var messagingProvider = builder.Configuration["MessagingProvider"] ?? "None";
+
+            if (messagingProvider == "RabbitMq")
+                builder.AddRabbitMqMessageBus();
+            else if (messagingProvider == "ServiceBus")
+                builder.AddServiceBusMessageBus();
+
             builder.Services.AddInfrastructure();
             builder.Services.AddApplication();
 

--- a/src/Api.Project.Template.Api/appsettings.json
+++ b/src/Api.Project.Template.Api/appsettings.json
@@ -7,6 +7,20 @@
   },
   "AllowedHosts": "*",
   "DatabaseProvider": "SqlServer",
+  "MessagingProvider": "RabbitMq",
+  "MessageBus": {
+    "Routing": {
+      "Provider": "Auto",
+      "DefaultDestination": "apiprojecttemplate.events",
+      "Routes": {
+        "WeatherForecastRequestedEvent": {
+          "Destination": "apiprojecttemplate.events",
+          "RoutingKey": "WeatherRequested",
+          "Subject": "WeatherRequested"
+        }
+      }
+    }
+  },
   "Serilog": {
     "MinimumLevel": {
       "Default": "Information",

--- a/src/Api.Project.Template.AppHost/Api.Project.Template.AppHost.csproj
+++ b/src/Api.Project.Template.AppHost/Api.Project.Template.AppHost.csproj
@@ -9,12 +9,15 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.Azure.ServiceBus" />
     <PackageReference Include="Aspire.Hosting.PostgreSQL" />
+    <PackageReference Include="Aspire.Hosting.RabbitMQ" />
     <PackageReference Include="Aspire.Hosting.SqlServer" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Api.Project.Template.Api\Api.Project.Template.Api.csproj" />
+    <ProjectReference Include="..\Api.Project.Template.Worker\Api.Project.Template.Worker.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Api.Project.Template.AppHost/AppHost.cs
+++ b/src/Api.Project.Template.AppHost/AppHost.cs
@@ -1,9 +1,14 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
 var provider = builder.Configuration["DatabaseProvider"] ?? "SqlServer";
+var messagingProvider = builder.Configuration["MessagingProvider"] ?? "None";
 
-var project = builder.AddProject<Projects.Api_Project_Template_Api>("api-project-template-api")
-    .WithEnvironment("DatabaseProvider", provider);
+var api = builder.AddProject<Projects.Api_Project_Template_Api>("api-project-template-api")
+    .WithEnvironment("DatabaseProvider", provider)
+    .WithEnvironment("MessagingProvider", messagingProvider);
+
+var worker = builder.AddProject<Projects.Api_Project_Template_Worker>("api-project-template-worker")
+    .WithEnvironment("MessagingProvider", messagingProvider);
 
 if (provider == "PostgreSQL")
 {
@@ -12,7 +17,7 @@ if (provider == "PostgreSQL")
         .WithLifetime(ContainerLifetime.Persistent)
         .AddDatabase("ApiProjectTemplate");
 
-    project.WithReference(pg).WaitFor(pg);
+    api.WithReference(pg).WaitFor(pg);
 }
 else
 {
@@ -21,7 +26,24 @@ else
         .WithLifetime(ContainerLifetime.Persistent)
         .AddDatabase("ApiProjectTemplate");
 
-    project.WithReference(sql).WaitFor(sql);
+    api.WithReference(sql).WaitFor(sql);
+}
+
+if (messagingProvider == "RabbitMq")
+{
+    var rabbit = builder.AddRabbitMQ("messaging")
+        .WithDataVolume(isReadOnly: false)
+        .WithLifetime(ContainerLifetime.Persistent)
+        .WithManagementPlugin();
+
+    api.WithReference(rabbit).WaitFor(rabbit);
+    worker.WithReference(rabbit).WaitFor(rabbit);
+}
+else if (messagingProvider == "ServiceBus")
+{
+    var serviceBus = builder.AddAzureServiceBus("servicebus");
+    api.WithReference(serviceBus);
+    worker.WithReference(serviceBus);
 }
 
 builder.Build().Run();

--- a/src/Api.Project.Template.AppHost/appsettings.json
+++ b/src/Api.Project.Template.AppHost/appsettings.json
@@ -6,5 +6,6 @@
       "Aspire.Hosting.Dcp": "Warning"
     }
   },
-  "DatabaseProvider": "SqlServer"
+  "DatabaseProvider": "SqlServer",
+  "MessagingProvider": "RabbitMq"
 }

--- a/src/Api.Project.Template.Application/Abstractions/Logging/ILoggerAdapter.cs
+++ b/src/Api.Project.Template.Application/Abstractions/Logging/ILoggerAdapter.cs
@@ -13,6 +13,9 @@ public interface ILoggerAdapter<T>
     void LogInformation<T0>(string message, T0 arg0);
     void LogInformation<T0, T1>(string message, T0 arg0, T1 arg1);
     void LogInformation<T0, T1, T2>(string message, T0 arg0, T1 arg1, T2 arg2);
+    void LogInformation<T0, T1, T2, T3>(string message, T0 arg0, T1 arg1, T2 arg2, T3 arg3);
+    void LogInformation<T0, T1, T2, T3, T4>(string message, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4);
+    void LogInformation<T0, T1, T2, T3, T4, T5>(string message, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5);
 
     void LogWarning(string message);
     void LogWarning<T0>(string message, T0 arg0);

--- a/src/Api.Project.Template.Application/Features/Weather/Events/WeatherForecastRequestedEvent.cs
+++ b/src/Api.Project.Template.Application/Features/Weather/Events/WeatherForecastRequestedEvent.cs
@@ -1,0 +1,8 @@
+using MediatR;
+
+namespace Api.Project.Template.Application.Features.Weather.Events;
+
+public record WeatherForecastRequestedEvent(
+    int Page,
+    int Size,
+    DateTimeOffset RequestedAt) : INotification;

--- a/src/Api.Project.Template.Application/Features/Weather/Events/WeatherForecastRequestedEventHandler.cs
+++ b/src/Api.Project.Template.Application/Features/Weather/Events/WeatherForecastRequestedEventHandler.cs
@@ -1,0 +1,11 @@
+using Api.Project.Template.Application.Messaging.Abstractions;
+using MediatR;
+
+namespace Api.Project.Template.Application.Features.Weather.Events;
+
+public class WeatherForecastRequestedEventHandler(IMessagePublisher messageBus)
+    : INotificationHandler<WeatherForecastRequestedEvent>
+{
+    public Task Handle(WeatherForecastRequestedEvent notification, CancellationToken cancellationToken)
+        => messageBus.PublishAsync(notification, cancellationToken: cancellationToken);
+}

--- a/src/Api.Project.Template.Application/Features/Weather/Queries/Handlers/GetWeatherForecastsQueryHandler.cs
+++ b/src/Api.Project.Template.Application/Features/Weather/Queries/Handlers/GetWeatherForecastsQueryHandler.cs
@@ -1,11 +1,12 @@
 using Api.Project.Template.Application.Abstractions;
 using Api.Project.Template.Application.Common.Pagination;
+using Api.Project.Template.Application.Features.Weather.Events;
 using Api.Project.Template.Application.Features.Weather.Specifications;
 using MediatR;
 
 namespace Api.Project.Template.Application.Features.Weather.Queries.Handlers;
 
-public class GetWeatherForecastsQueryHandler(IRepository repository)
+public class GetWeatherForecastsQueryHandler(IRepository repository, IPublisher publisher)
     : IRequestHandler<GetWeatherForecastsQuery, PagedList<GetWeatherForecastsResponse>>
 {
     public async Task<PagedList<GetWeatherForecastsResponse>> Handle(
@@ -13,6 +14,18 @@ public class GetWeatherForecastsQueryHandler(IRepository repository)
         CancellationToken cancellationToken)
     {
         var spec = new WeatherForecastFilterSpecification(request.PaginationRequest);
-        return await repository.ListAsync(spec, cancellationToken);
+        var result = await repository.ListAsync(spec, cancellationToken);
+
+        // Contrived example to demonstrate MediatR's publish/subscribe capabilities.
+        // In a real application, you might want to publish an event when a new weather forecast is created or updated,
+        // rather than when forecasts are requested.
+        await publisher.Publish(
+            new WeatherForecastRequestedEvent(
+                request.PaginationRequest.Page,
+                request.PaginationRequest.Size,
+                DateTimeOffset.UtcNow),
+            cancellationToken);
+
+        return result;
     }
 }

--- a/src/Api.Project.Template.Application/Messaging/Abstractions/IMessageProcessor.cs
+++ b/src/Api.Project.Template.Application/Messaging/Abstractions/IMessageProcessor.cs
@@ -1,0 +1,31 @@
+namespace Api.Project.Template.Application.Messaging.Abstractions;
+
+/// <summary>
+/// Generic message processor interface.
+/// Implementations handle processing logic for a specific message type.
+/// </summary>
+/// <typeparam name="TMessage">The type of message this processor handles.</typeparam>
+public interface IMessageProcessor<in TMessage>
+{
+    /// <summary>
+    /// Processes a message and returns the result.
+    /// </summary>
+    /// <param name="message">The message to process.</param>
+    /// <param name="context">
+    /// Message context containing metadata like correlation ID, delivery count, and cancellation token.
+    /// </param>
+    /// <returns>
+    /// A task that represents the asynchronous processing operation.
+    /// The task result indicates success or failure and whether to requeue on failure.
+    /// </returns>
+    /// <remarks>
+    /// Implementation guidelines:
+    /// - Use context.CancellationToken to check for cancellation
+    /// - Use context.CorrelationId for distributed tracing
+    /// - Return MessageProcessingResult.Succeeded() on success
+    /// - Return MessageProcessingResult.Failed(reason, requeue: true) for transient errors (network, database timeout)
+    /// - Return MessageProcessingResult.Failed(reason, requeue: false) for permanent errors (validation, business logic)
+    /// - Catch and handle expected exceptions, let unexpected exceptions bubble up
+    /// </remarks>
+    Task<MessageProcessingResult> ProcessAsync(TMessage message, MessageContext context);
+}

--- a/src/Api.Project.Template.Application/Messaging/Abstractions/IMessagePublisher.cs
+++ b/src/Api.Project.Template.Application/Messaging/Abstractions/IMessagePublisher.cs
@@ -1,0 +1,15 @@
+namespace Api.Project.Template.Application.Messaging.Abstractions;
+
+/// <summary>
+/// Defines a message publisher that can send messages to a message broker.
+/// </summary>
+public interface IMessagePublisher
+{
+    /// <summary>
+    /// Publishes a message with provider-specific routing options.
+    /// </summary>
+    /// <param name="message">The message to publish</param>
+    /// <param name="options">Optional routing and delivery options</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    Task PublishAsync<T>(T message, MessagePublishOptions? options = null, CancellationToken cancellationToken = default);
+}

--- a/src/Api.Project.Template.Application/Messaging/MessageContext.cs
+++ b/src/Api.Project.Template.Application/Messaging/MessageContext.cs
@@ -1,0 +1,45 @@
+namespace Api.Project.Template.Application.Messaging;
+
+/// <summary>
+/// Message metadata and control context passed to message handlers.
+/// Contains all contextual information about a received message.
+/// </summary>
+public class MessageContext
+{
+    /// <summary>
+    /// Unique message identifier assigned by the message broker.
+    /// </summary>
+    public string MessageId { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Correlation ID for distributed tracing and request tracking.
+    /// Used to correlate related messages across different services.
+    /// </summary>
+    public string CorrelationId { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Number of times this message has been delivered.
+    /// Starts at 1 for first delivery, increments on each retry.
+    /// </summary>
+    public int DeliveryCount { get; init; }
+
+    /// <summary>
+    /// Message headers and properties.
+    /// Contains metadata like content type, timestamp, custom headers, etc.
+    /// </summary>
+    public IReadOnlyDictionary<string, object> Headers { get; init; } =
+        new Dictionary<string, object>();
+
+    /// <summary>
+    /// Cancellation token for processing timeout and graceful shutdown.
+    /// Processors should check this token and cancel long-running operations when requested.
+    /// </summary>
+    public CancellationToken CancellationToken { get; init; }
+
+    /// <summary>
+    /// Provider-specific metadata for advanced scenarios.
+    /// Contains broker-specific objects like delivery tags, partition keys, etc.
+    /// This is internal and used by adapters to pass provider-specific context.
+    /// </summary>
+    internal object? ProviderContext { get; init; }
+}

--- a/src/Api.Project.Template.Application/Messaging/MessageProcessingResult.cs
+++ b/src/Api.Project.Template.Application/Messaging/MessageProcessingResult.cs
@@ -1,0 +1,62 @@
+namespace Api.Project.Template.Application.Messaging;
+
+/// <summary>
+/// Result of message processing, determines ACK/NACK/Dead-letter behavior.
+/// </summary>
+public class MessageProcessingResult
+{
+    /// <summary>
+    /// Indicates whether the message was processed successfully.
+    /// </summary>
+    public bool Success { get; init; }
+
+    /// <summary>
+    /// Indicates whether the message should be requeued for retry if processing failed.
+    /// Only applicable when Success is false.
+    /// </summary>
+    public bool Requeue { get; init; }
+
+    /// <summary>
+    /// Human-readable error reason if processing failed.
+    /// </summary>
+    public string? ErrorReason { get; init; }
+
+    /// <summary>
+    /// Exception that caused the processing failure, if any.
+    /// </summary>
+    public Exception? Exception { get; init; }
+
+    /// <summary>
+    /// Creates a successful processing result.
+    /// The message will be acknowledged (ACKed) and removed from the queue.
+    /// </summary>
+    /// <returns>A MessageProcessingResult indicating success.</returns>
+    public static MessageProcessingResult Succeeded() =>
+        new() { Success = true };
+
+    /// <summary>
+    /// Creates a failed processing result.
+    /// The message will be negatively acknowledged (NACKed).
+    /// </summary>
+    /// <param name="reason">The reason for the failure.</param>
+    /// <param name="requeue">
+    /// If true, the message will be requeued for retry.
+    /// If false, the message will be dead-lettered (after max retries).
+    /// </param>
+    /// <returns>A MessageProcessingResult indicating failure.</returns>
+    public static MessageProcessingResult Failed(string reason, bool requeue = false) =>
+        new() { Success = false, Requeue = requeue, ErrorReason = reason };
+
+    /// <summary>
+    /// Creates a failed processing result with an exception.
+    /// The message will be negatively acknowledged (NACKed).
+    /// </summary>
+    /// <param name="ex">The exception that caused the failure.</param>
+    /// <param name="requeue">
+    /// If true, the message will be requeued for retry.
+    /// If false, the message will be dead-lettered (after max retries).
+    /// </param>
+    /// <returns>A MessageProcessingResult indicating failure with exception details.</returns>
+    public static MessageProcessingResult FailedWithException(Exception ex, bool requeue = false) =>
+        new() { Success = false, Requeue = requeue, Exception = ex, ErrorReason = ex.Message };
+}

--- a/src/Api.Project.Template.Application/Messaging/MessagePublishOptions.cs
+++ b/src/Api.Project.Template.Application/Messaging/MessagePublishOptions.cs
@@ -1,0 +1,25 @@
+namespace Api.Project.Template.Application.Messaging;
+
+/// <summary>
+/// Options for publishing a message. Provider-agnostic wrapper for routing and delivery options.
+/// </summary>
+public class MessagePublishOptions
+{
+    /// <summary>
+    /// The destination topic/queue/subject for the message.
+    /// Maps to: RabbitMQ exchange, Azure Service Bus topic, AWS SNS topic, etc.
+    /// </summary>
+    public string? Destination { get; init; }
+
+    /// <summary>
+    /// The routing key or subject for the message.
+    /// Maps to: RabbitMQ routing key, Azure Service Bus subject, AWS SNS message attributes, etc.
+    /// </summary>
+    public string? Subject { get; init; }
+
+    /// <summary>
+    /// Additional metadata for the message.
+    /// Maps to provider-specific headers/properties.
+    /// </summary>
+    public IDictionary<string, object>? Metadata { get; init; }
+}

--- a/src/Api.Project.Template.Infrastructure/Api.Project.Template.Infrastructure.csproj
+++ b/src/Api.Project.Template.Infrastructure/Api.Project.Template.Infrastructure.csproj
@@ -7,11 +7,23 @@
   </PropertyGroup>
 
   <ItemGroup>
+	<InternalsVisibleTo Include="Api.Project.Template.Tests.Unit" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Ardalis.Specification.EntityFrameworkCore" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
+    <PackageReference Include="RabbitMQ.Client" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Api.Project.Template.Infrastructure/Logging/LoggerAdapter.cs
+++ b/src/Api.Project.Template.Infrastructure/Logging/LoggerAdapter.cs
@@ -77,6 +77,30 @@ public class LoggerAdapter<T> : ILoggerAdapter<T>
         }
     }
 
+    public void LogInformation<T0, T1, T2, T3>(string message, T0 arg0, T1 arg1, T2 arg2, T3 arg3)
+    {
+        if (_logger.IsEnabled(LogLevel.Information))
+        {
+            _logger.LogInformation(message, arg0, arg1, arg2, arg3);
+        }
+    }
+
+    public void LogInformation<T0, T1, T2, T3, T4>(string message, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+    {
+        if (_logger.IsEnabled(LogLevel.Information))
+        {
+            _logger.LogInformation(message, arg0, arg1, arg2, arg3, arg4);
+        }
+    }
+
+    public void LogInformation<T0, T1, T2, T3, T4, T5>(string message, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+    {
+        if (_logger.IsEnabled(LogLevel.Information))
+        {
+            _logger.LogInformation(message, arg0, arg1, arg2, arg3, arg4, arg5);
+        }
+    }
+
     public void LogWarning(string message)
     {
         if (_logger.IsEnabled(LogLevel.Warning))

--- a/src/Api.Project.Template.Infrastructure/Messaging/Abstractions/IMessageBrokerAdapter.cs
+++ b/src/Api.Project.Template.Infrastructure/Messaging/Abstractions/IMessageBrokerAdapter.cs
@@ -1,0 +1,69 @@
+using Api.Project.Template.Application.Messaging;
+
+namespace Api.Project.Template.Infrastructure.Messaging.Abstractions;
+
+/// <summary>
+/// Adapter interface for message broker operations.
+/// Implementations wrap broker-specific APIs (RabbitMQ, Azure Service Bus, etc.)
+/// to provide a consistent interface for consuming messages.
+/// </summary>
+public interface IMessageBrokerAdapter : IAsyncDisposable
+{
+    /// <summary>
+    /// Configures the adapter and, where possible, establishes the broker connection.
+    /// </summary>
+    /// <param name="config">The broker configuration including connection string, queue name, and concurrency settings.</param>
+    /// <param name="cancellationToken">Cancellation token to abort the operation.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when configuration is invalid or missing required values.</exception>
+    /// <remarks>
+    /// Implementations are expected to store <paramref name="config"/> and prepare any resources needed
+    /// before <see cref="SubscribeAsync{TMessage}"/> is called.
+    /// <para>
+    /// Eager connection (RabbitMQ): the physical TCP connection and channel are opened here.
+    /// </para>
+    /// <para>
+    /// Deferred connection (Azure Service Bus): the SDK processor is configured here but the
+    /// underlying connection is not opened until <see cref="SubscribeAsync{TMessage}"/> calls
+    /// <c>StartProcessingAsync</c>. This is a deliberate SDK design choice — there is no
+    /// connect-only API on <c>ServiceBusProcessor</c>.
+    /// </para>
+    /// </remarks>
+    Task ConnectAsync(MessageBrokerConfig config, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Subscribes to messages of type TMessage and routes them to the provided handler.
+    /// </summary>
+    /// <typeparam name="TMessage">The type of message to consume (will be deserialized from JSON).</typeparam>
+    /// <param name="handler">
+    /// The handler function to process received messages.
+    /// Receives the deserialized message and metadata context, returns processing result.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token to stop consuming messages.</param>
+    /// <returns>A task that represents the asynchronous subscribe operation.</returns>
+    /// <remarks>
+    /// This method should:
+    /// - Start consuming messages from the configured queue
+    /// - Deserialize message payload to TMessage
+    /// - Create MessageContext with metadata (correlation ID, delivery count, etc.)
+    /// - Invoke the handler and await the result
+    /// - Based on result: ACK (success), NACK with requeue (transient failure), or dead-letter (permanent failure)
+    /// - Respect concurrency limits (max concurrent handlers)
+    /// </remarks>
+    Task SubscribeAsync<TMessage>(
+        Func<TMessage, MessageContext, Task<MessageProcessingResult>> handler,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Disconnects from the message broker and cleans up resources.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous disconnect operation.</returns>
+    /// <remarks>
+    /// This method should:
+    /// - Stop consuming new messages
+    /// - Allow in-flight messages to complete (graceful shutdown)
+    /// - Close broker connections
+    /// - Release resources (channels, connections, semaphores)
+    /// </remarks>
+    Task DisconnectAsync();
+}

--- a/src/Api.Project.Template.Infrastructure/Messaging/Abstractions/IMessageConsumer.cs
+++ b/src/Api.Project.Template.Infrastructure/Messaging/Abstractions/IMessageConsumer.cs
@@ -1,0 +1,17 @@
+namespace Api.Project.Template.Infrastructure.Messaging.Abstractions;
+
+/// <summary>
+/// Defines a message consumer that can subscribe to and process messages from a message broker.
+/// </summary>
+public interface IMessageConsumer : IAsyncDisposable, IDisposable
+{
+    /// <summary>
+    /// Starts consuming messages from the message broker.
+    /// </summary>
+    Task StartAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Stops consuming messages from the message broker.
+    /// </summary>
+    Task StopAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Api.Project.Template.Infrastructure/Messaging/GenericMessageConsumer.cs
+++ b/src/Api.Project.Template.Infrastructure/Messaging/GenericMessageConsumer.cs
@@ -1,0 +1,153 @@
+using Api.Project.Template.Application.Abstractions.Logging;
+using Api.Project.Template.Application.Messaging;
+using Api.Project.Template.Application.Messaging.Abstractions;
+using Api.Project.Template.Infrastructure.Messaging.Abstractions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Api.Project.Template.Infrastructure.Messaging;
+
+/// <summary>
+/// Generic message consumer that works with any broker via IMessageBrokerAdapter.
+/// Resolves message processors from DI and delegates message handling to them.
+/// </summary>
+/// <typeparam name="TMessage">The type of message to consume</typeparam>
+/// <typeparam name="TProcessor">The processor type that handles TMessage</typeparam>
+public class GenericMessageConsumer<TMessage, TProcessor>(
+    IMessageBrokerAdapter adapter,
+    IConfiguration configuration,
+    IServiceScopeFactory scopeFactory,
+    ILoggerAdapter<GenericMessageConsumer<TMessage, TProcessor>> logger)
+    : IMessageConsumer
+    where TProcessor : IMessageProcessor<TMessage>
+{
+    public async Task StartAsync(CancellationToken cancellationToken = default)
+    {
+        var config = BuildConfiguration();
+
+        await adapter.ConnectAsync(config, cancellationToken);
+        await adapter.SubscribeAsync<TMessage>(ProcessMessageAsync, cancellationToken);
+
+        logger.LogInformation(
+            "GenericMessageConsumer<{MessageType}, {ProcessorType}> started (Queue: {Queue})",
+            typeof(TMessage).Name,
+            typeof(TProcessor).Name,
+            config.Queue);
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken = default)
+    {
+        await adapter.DisconnectAsync();
+
+        logger.LogInformation(
+            "GenericMessageConsumer<{MessageType}, {ProcessorType}> stopped",
+            typeof(TMessage).Name,
+            typeof(TProcessor).Name);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await adapter.DisposeAsync();
+        GC.SuppressFinalize(this);
+    }
+
+    public void Dispose()
+    {
+        DisposeAsync().AsTask().GetAwaiter().GetResult();
+        GC.SuppressFinalize(this);
+    }
+
+    private async Task<MessageProcessingResult> ProcessMessageAsync(
+        TMessage message,
+        MessageContext context)
+    {
+        try
+        {
+            using var scope = scopeFactory.CreateScope();
+            var processor = scope.ServiceProvider.GetRequiredService<TProcessor>();
+
+            logger.LogDebug(
+                "Processing {MessageType} (MessageId: {MessageId}, CorrelationId: {CorrelationId})",
+                typeof(TMessage).Name,
+                context.MessageId,
+                context.CorrelationId);
+
+            var result = await processor.ProcessAsync(message, context);
+
+            if (result.Success)
+            {
+                logger.LogInformation(
+                    "Successfully processed {MessageType} (MessageId: {MessageId})",
+                    typeof(TMessage).Name,
+                    context.MessageId);
+            }
+            else
+            {
+                logger.LogWarning(
+                    "Failed to process {MessageType} (MessageId: {MessageId}, Reason: {Reason})",
+                    typeof(TMessage).Name,
+                    context.MessageId,
+                    result.ErrorReason);
+            }
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex,
+                "Unhandled exception processing {MessageType} (MessageId: {MessageId})",
+                typeof(TMessage).Name,
+                context.MessageId);
+
+            return MessageProcessingResult.FailedWithException(ex, requeue: false);
+        }
+    }
+
+    private MessageBrokerConfig BuildConfiguration()
+    {
+        // Aspire injects broker connection strings under ConnectionStrings:<resource-name>.
+        // RabbitMQ resource is named "messaging"; Azure Service Bus resource is named "servicebus".
+        var connectionString =
+            configuration.GetConnectionString("messaging")
+            ?? configuration.GetConnectionString("servicebus")
+            ?? throw new InvalidOperationException(
+                "Message broker connection string not configured. " +
+                "Aspire should inject ConnectionStrings:messaging (RabbitMQ) or ConnectionStrings:servicebus (Azure Service Bus).");
+
+        var config = new MessageBrokerConfig
+        {
+            ConnectionString = connectionString,
+            Queue = configuration["MessageBus:Consumer:Queue"]
+                ?? throw new InvalidOperationException("MessageBus:Consumer:Queue not configured"),
+            Concurrency = int.TryParse(configuration["MessageBus:Consumer:Concurrency"], out var concurrency)
+                ? concurrency
+                : 5,
+            MaxRetries = int.TryParse(configuration["MessageBus:Consumer:MaxRetries"], out var maxRetries)
+                ? maxRetries
+                : 3,
+            PrefetchCount = int.TryParse(configuration["MessageBus:Consumer:PrefetchCount"], out var prefetchCount)
+                ? prefetchCount
+                : 10
+        };
+
+        // RabbitMQ-specific configuration
+        var exchange = configuration["MessageBus:RabbitMq:Exchange"];
+        if (!string.IsNullOrWhiteSpace(exchange))
+            config.ProviderSpecific["Exchange"] = exchange;
+
+        var routingKey = configuration["MessageBus:RabbitMq:RoutingKey"];
+        if (!string.IsNullOrWhiteSpace(routingKey))
+            config.ProviderSpecific["RoutingKey"] = routingKey;
+
+        var exchangeType = configuration["MessageBus:RabbitMq:ExchangeType"];
+        if (!string.IsNullOrWhiteSpace(exchangeType))
+            config.ProviderSpecific["ExchangeType"] = exchangeType;
+
+        // Azure Service Bus-specific configuration
+        var subscriptionName = configuration["MessageBus:ServiceBus:SubscriptionName"];
+        if (!string.IsNullOrWhiteSpace(subscriptionName))
+            config.ProviderSpecific["SubscriptionName"] = subscriptionName;
+
+        return config;
+    }
+}

--- a/src/Api.Project.Template.Infrastructure/Messaging/MessageBrokerConfig.cs
+++ b/src/Api.Project.Template.Infrastructure/Messaging/MessageBrokerConfig.cs
@@ -1,0 +1,50 @@
+namespace Api.Project.Template.Infrastructure.Messaging;
+
+/// <summary>
+/// Provider-agnostic message broker configuration.
+/// Used to configure connection and behavior for any message broker implementation.
+/// </summary>
+public class MessageBrokerConfig
+{
+    /// <summary>
+    /// Connection string in broker-specific format.
+    /// Examples:
+    /// - RabbitMQ: "amqp://guest:guest@localhost:5672/" or "Host=localhost;Username=guest;Password=guest"
+    /// - Azure Service Bus: "Endpoint=sb://namespace.servicebus.windows.net/;SharedAccessKeyName=..."
+    /// </summary>
+    public string ConnectionString { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Queue or topic name to consume messages from.
+    /// </summary>
+    public string Queue { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Number of concurrent message processors.
+    /// Controls how many messages can be processed in parallel.
+    /// Default: 5
+    /// </summary>
+    public int Concurrency { get; set; } = 5;
+
+    /// <summary>
+    /// Maximum number of retry attempts before dead-lettering a message.
+    /// Default: 3
+    /// </summary>
+    public int MaxRetries { get; set; } = 3;
+
+    /// <summary>
+    /// Number of messages to prefetch and buffer locally.
+    /// Higher values improve throughput but increase memory usage.
+    /// Default: 10
+    /// </summary>
+    public int PrefetchCount { get; set; } = 10;
+
+    /// <summary>
+    /// Provider-specific configuration overrides.
+    /// Use this dictionary to pass broker-specific settings that don't fit the generic model.
+    /// Examples:
+    /// - RabbitMQ: "Exchange", "RoutingKey", "ExchangeType"
+    /// - Azure Service Bus: "SubscriptionName", "SessionEnabled"
+    /// </summary>
+    public Dictionary<string, string> ProviderSpecific { get; set; } = new();
+}

--- a/src/Api.Project.Template.Infrastructure/Messaging/MessageBusExtensions.cs
+++ b/src/Api.Project.Template.Infrastructure/Messaging/MessageBusExtensions.cs
@@ -1,0 +1,215 @@
+using Api.Project.Template.Application.Abstractions.Logging;
+using Api.Project.Template.Application.Messaging.Abstractions;
+using Api.Project.Template.Infrastructure.Messaging.Abstractions;
+using Api.Project.Template.Infrastructure.Messaging.RabbitMq;
+using Api.Project.Template.Infrastructure.Messaging.ServiceBus;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Api.Project.Template.Infrastructure.Messaging;
+
+/// <summary>
+/// Extension methods for configuring message bus with routing abstraction.
+/// </summary>
+public static class MessageBusExtensions
+{
+    /// <summary>
+    /// Adds message bus with automatic provider selection based on configuration.
+    /// Registers both IMessagePublisher and IMessageBrokerAdapter for the selected provider.
+    /// Provider determined by MessageBus:Routing:Provider setting ("RabbitMq", "ServiceBus", "Auto").
+    /// </summary>
+    /// <param name="services">The service collection</param>
+    /// <param name="configuration">The configuration root</param>
+    /// <returns>The service collection for chaining</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when provider is invalid or required connection strings are missing.
+    /// </exception>
+    public static IServiceCollection AddMessageBus(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        // Bind routing configuration
+        services.Configure<MessageRoutingConfig>(
+            configuration.GetSection("MessageBus:Routing"));
+
+        var routingConfig = configuration
+            .GetSection("MessageBus:Routing")
+            .Get<MessageRoutingConfig>() ?? new MessageRoutingConfig();
+
+        var provider = ResolveProvider(routingConfig.Provider, configuration);
+
+        // Register publisher and consumer adapter based on provider
+        if (provider == "RabbitMq")
+        {
+            RegisterRabbitMq(services);
+        }
+        else if (provider == "ServiceBus")
+        {
+            RegisterServiceBus(services);
+        }
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers a message consumer and its background host for the given message and processor types.
+    /// Uses <see cref="MessageConsumerWorker{TMessage,TProcessor}"/> as the hosted service.
+    /// </summary>
+    /// <typeparam name="TMessage">The message type to consume.</typeparam>
+    /// <typeparam name="TProcessor">
+    /// The processor class that handles <typeparamref name="TMessage"/>.
+    /// Registered as scoped to support per-message dependency injection (e.g. DbContext).
+    /// </typeparam>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    /// <remarks>
+    /// Call <see cref="AddMessageBus"/> before calling this method.
+    /// For a named hosted service (better log output, customizable per service),
+    /// use the <c>AddMessageConsumer&lt;TMessage, TProcessor, TWorker&gt;</c> overload instead.
+    /// </remarks>
+    public static IServiceCollection AddMessageConsumer<TMessage, TProcessor>(
+        this IServiceCollection services)
+        where TProcessor : class, IMessageProcessor<TMessage>
+        => services.AddMessageConsumer<TMessage, TProcessor, MessageConsumerWorker<TMessage, TProcessor>>();
+
+    /// <summary>
+    /// Registers a message consumer and its background host for the given message, processor, and worker types.
+    /// </summary>
+    /// <typeparam name="TMessage">The message type to consume.</typeparam>
+    /// <typeparam name="TProcessor">
+    /// The processor class that handles <typeparamref name="TMessage"/>.
+    /// Registered as scoped to support per-message dependency injection (e.g. DbContext).
+    /// </typeparam>
+    /// <typeparam name="TWorker">
+    /// A <see cref="MessageConsumerWorker{TMessage,TProcessor}"/> subclass to use as the hosted service.
+    /// Allows service-specific log names and lifecycle customization.
+    /// </typeparam>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    /// <remarks>
+    /// Call <see cref="AddMessageBus"/> before calling this method.
+    /// </remarks>
+    public static IServiceCollection AddMessageConsumer<TMessage, TProcessor, TWorker>(
+        this IServiceCollection services)
+        where TProcessor : class, IMessageProcessor<TMessage>
+        where TWorker : MessageConsumerWorker<TMessage, TProcessor>
+    {
+        services.AddScoped<TProcessor>();
+        services.AddSingleton<IMessageConsumer, GenericMessageConsumer<TMessage, TProcessor>>();
+        services.AddHostedService<TWorker>();
+        return services;
+    }
+
+    /// <summary>
+    /// Resolves the provider string to a normalized value, handling auto-detection.
+    /// </summary>
+    internal static string ResolveProvider(string? providerValue, IConfiguration configuration)
+    {
+        return providerValue?.ToLowerInvariant() switch
+        {
+            "rabbitmq" => "RabbitMq",
+            "servicebus" => "ServiceBus",
+            "auto" or null or "" => DetectProvider(configuration),
+            _ => throw new InvalidOperationException(
+                $"Invalid MessageBus:Routing:Provider value: '{providerValue}'. " +
+                $"Valid values: 'RabbitMq', 'ServiceBus', 'Auto'")
+        };
+    }
+
+    /// <summary>
+    /// Registers RabbitMQ implementations for both publisher and consumer.
+    /// Registers IMessagePublisher with RoutingMessagePublisher decorator and IMessageBrokerAdapter with RabbitMqBrokerAdapter.
+    /// </summary>
+    /// <param name="services">The service collection</param>
+    private static void RegisterRabbitMq(IServiceCollection services)
+    {
+        // Register publisher
+        services.AddSingleton<RabbitMqMessagePublisher>();
+        services.AddSingleton<IMessagePublisher>(sp =>
+        {
+            var innerPublisher = sp.GetRequiredService<RabbitMqMessagePublisher>();
+            var routingOptions = sp.GetRequiredService<IOptions<MessageRoutingConfig>>();
+            var logger = sp.GetRequiredService<ILoggerAdapter<RoutingMessagePublisher>>();
+
+            logger.LogInformation("Message bus publisher configured with provider: RabbitMq");
+
+            return new RoutingMessagePublisher(innerPublisher, routingOptions, logger);
+        });
+
+        // Register consumer adapter
+        services.AddSingleton<IMessageBrokerAdapter, RabbitMqBrokerAdapter>();
+    }
+
+    /// <summary>
+    /// Registers Azure Service Bus implementations for both publisher and consumer.
+    /// Registers IMessagePublisher with RoutingMessagePublisher decorator and IMessageBrokerAdapter with ServiceBusBrokerAdapter.
+    /// </summary>
+    /// <param name="services">The service collection</param>
+    private static void RegisterServiceBus(IServiceCollection services)
+    {
+        // Register publisher
+        services.AddSingleton<ServiceBusMessagePublisher>();
+        services.AddSingleton<IMessagePublisher>(sp =>
+        {
+            var innerPublisher = sp.GetRequiredService<ServiceBusMessagePublisher>();
+            var routingOptions = sp.GetRequiredService<IOptions<MessageRoutingConfig>>();
+            var logger = sp.GetRequiredService<ILoggerAdapter<RoutingMessagePublisher>>();
+
+            logger.LogInformation("Message bus publisher configured with provider: ServiceBus");
+
+            return new RoutingMessagePublisher(innerPublisher, routingOptions, logger);
+        });
+
+        // Register consumer adapter
+        services.AddSingleton<IMessageBrokerAdapter, ServiceBusBrokerAdapter>();
+    }
+
+    /// <summary>
+    /// Detects available provider by checking for connection strings.
+    /// </summary>
+    internal static string DetectProvider(IConfiguration configuration)
+    {
+        var hasRabbitMq = HasRabbitMqConnectionString(configuration);
+        var hasServiceBus = HasServiceBusConnectionString(configuration);
+
+        if (hasServiceBus && hasRabbitMq)
+        {
+            // Both available - prefer RabbitMq for local development compatibility
+            return "RabbitMq";
+        }
+
+        if (hasServiceBus)
+            return "ServiceBus";
+
+        if (hasRabbitMq)
+            return "RabbitMq";
+
+        throw new InvalidOperationException(
+            "No message broker connection string found. " +
+            "Set ConnectionStrings:messaging (RabbitMQ) or ConnectionStrings:servicebus (Azure Service Bus), " +
+            "or explicitly set MessageBus:Routing:Provider.");
+    }
+
+    /// <summary>
+    /// Checks if any RabbitMQ connection string is configured.
+    /// </summary>
+    internal static bool HasRabbitMqConnectionString(IConfiguration configuration)
+    {
+        return !string.IsNullOrEmpty(configuration["MessageBus:RabbitMq:ConnectionString"])
+            || !string.IsNullOrEmpty(configuration["MessageBus:RabbitMq"])
+            || !string.IsNullOrEmpty(configuration["MessageBus__RabbitMq__ConnectionString"])
+            || !string.IsNullOrEmpty(configuration["MessageBus__RabbitMq"])
+            || !string.IsNullOrEmpty(configuration.GetConnectionString("RabbitMq"))
+            || !string.IsNullOrEmpty(configuration.GetConnectionString("messaging"));
+    }
+
+    /// <summary>
+    /// Checks if Azure Service Bus connection string is configured.
+    /// </summary>
+    internal static bool HasServiceBusConnectionString(IConfiguration configuration)
+    {
+        return !string.IsNullOrEmpty(configuration["ConnectionStrings:servicebus"])
+            || !string.IsNullOrEmpty(configuration.GetConnectionString("servicebus"));
+    }
+}

--- a/src/Api.Project.Template.Infrastructure/Messaging/MessageConsumerWorker.cs
+++ b/src/Api.Project.Template.Infrastructure/Messaging/MessageConsumerWorker.cs
@@ -1,0 +1,73 @@
+using Api.Project.Template.Application.Abstractions.Logging;
+using Api.Project.Template.Application.Messaging.Abstractions;
+using Api.Project.Template.Infrastructure.Messaging.Abstractions;
+using Microsoft.Extensions.Hosting;
+
+namespace Api.Project.Template.Infrastructure.Messaging;
+
+/// <summary>
+/// Generic background service that hosts an <see cref="IMessageConsumer"/>.
+/// Registered automatically by <see cref="MessageBusExtensions.AddMessageConsumer{TMessage,TProcessor}"/>.
+/// </summary>
+public class MessageConsumerWorker<TMessage, TProcessor>(
+    IMessageConsumer consumer,
+    ILoggerAdapter<MessageConsumerWorker<TMessage, TProcessor>> logger)
+    : BackgroundService
+    where TProcessor : IMessageProcessor<TMessage>
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        logger.LogInformation(
+            "MessageConsumerWorker<{MessageType}, {ProcessorType}> starting.",
+            typeof(TMessage).Name, typeof(TProcessor).Name);
+
+        try
+        {
+            await consumer.StartAsync(stoppingToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex,
+                "Failed to start consumer for {MessageType}. Host will stop.",
+                typeof(TMessage).Name);
+            throw;
+        }
+
+        try
+        {
+            await Task.Delay(Timeout.Infinite, stoppingToken);
+        }
+        catch (OperationCanceledException)
+        {
+            // expected on host shutdown
+        }
+        finally
+        {
+            logger.LogInformation(
+                "MessageConsumerWorker<{MessageType}, {ProcessorType}> stopping.",
+                typeof(TMessage).Name, typeof(TProcessor).Name);
+
+            try
+            {
+                await consumer.StopAsync(stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error stopping consumer for {MessageType}.", typeof(TMessage).Name);
+            }
+
+            try
+            {
+                consumer.Dispose();
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Exception disposing consumer for {MessageType}.", typeof(TMessage).Name);
+            }
+
+            logger.LogInformation(
+                "MessageConsumerWorker<{MessageType}, {ProcessorType}> stopped.",
+                typeof(TMessage).Name, typeof(TProcessor).Name);
+        }
+    }
+}

--- a/src/Api.Project.Template.Infrastructure/Messaging/MessageRoutingConfig.cs
+++ b/src/Api.Project.Template.Infrastructure/Messaging/MessageRoutingConfig.cs
@@ -1,0 +1,64 @@
+namespace Api.Project.Template.Infrastructure.Messaging;
+
+/// <summary>
+/// Configuration for message routing, independent of broker implementation.
+/// Mapped from appsettings.json MessageBus:Routing section.
+/// </summary>
+public class MessageRoutingConfig
+{
+    /// <summary>
+    /// Active message broker provider.
+    /// Valid values: "RabbitMq", "ServiceBus", "Auto"
+    /// When "Auto", the provider is detected from available connection strings.
+    /// </summary>
+    public string Provider { get; init; } = "Auto";
+
+    /// <summary>
+    /// Default destination if message type not found in Routes.
+    /// Maps to RabbitMQ exchange or Azure Service Bus queue/topic.
+    /// </summary>
+    public string? DefaultDestination { get; init; }
+
+    /// <summary>
+    /// Default routing key for RabbitMQ if not specified per message.
+    /// Used as fallback when message type has no explicit RoutingKey.
+    /// </summary>
+    public string? DefaultRoutingKey { get; init; }
+
+    /// <summary>
+    /// Per-message-type routing configuration.
+    /// Key: Message type name (e.g., "WeatherRequested")
+    /// Value: Route configuration for that message
+    /// </summary>
+    public Dictionary<string, MessageRoute> Routes { get; init; } = new();
+}
+
+/// <summary>
+/// Routing configuration for a specific message type.
+/// </summary>
+public class MessageRoute
+{
+    /// <summary>
+    /// Destination name: RabbitMQ exchange, Azure Service Bus queue/topic.
+    /// If null, uses MessageRoutingConfig.DefaultDestination.
+    /// </summary>
+    public string? Destination { get; init; }
+
+    /// <summary>
+    /// Routing key for RabbitMQ topic exchanges.
+    /// Maps to MessagePublishOptions.Subject for broker abstraction.
+    /// </summary>
+    public string? RoutingKey { get; init; }
+
+    /// <summary>
+    /// Subject for Azure Service Bus filtering.
+    /// Maps to MessagePublishOptions.Subject for broker abstraction.
+    /// </summary>
+    public string? Subject { get; init; }
+
+    /// <summary>
+    /// Additional provider-specific metadata.
+    /// Can be used for custom headers or properties.
+    /// </summary>
+    public Dictionary<string, string>? Metadata { get; init; }
+}

--- a/src/Api.Project.Template.Infrastructure/Messaging/RabbitMq/RabbitMqBrokerAdapter.cs
+++ b/src/Api.Project.Template.Infrastructure/Messaging/RabbitMq/RabbitMqBrokerAdapter.cs
@@ -1,0 +1,285 @@
+using Api.Project.Template.Application.Abstractions.Logging;
+using Api.Project.Template.Application.Messaging;
+using Api.Project.Template.Infrastructure.Messaging.Abstractions;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+using System.Text;
+using System.Text.Json;
+
+namespace Api.Project.Template.Infrastructure.Messaging.RabbitMq;
+
+/// <summary>
+/// RabbitMQ implementation of IMessageBrokerAdapter.
+/// Wraps RabbitMQ.Client APIs to provide a consistent interface for message consumption.
+/// </summary>
+public class RabbitMqBrokerAdapter(ILoggerAdapter<RabbitMqBrokerAdapter> logger) : IMessageBrokerAdapter
+{
+    private readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+    private readonly SemaphoreSlim _channelLock = new(1, 1);
+
+    private IConnection? _connection;
+    private IChannel? _channel;
+    private SemaphoreSlim? _semaphore;
+    private string? _queueName;
+
+    public async Task ConnectAsync(MessageBrokerConfig config, CancellationToken cancellationToken)
+    {
+        _queueName = config.Queue;
+
+        // Parse connection string
+        var factory = RabbitMqConnectionStringParser.Parse(config.ConnectionString);
+
+        // Set resilience settings
+        factory.AutomaticRecoveryEnabled = true;
+        factory.TopologyRecoveryEnabled = true;
+        factory.NetworkRecoveryInterval = TimeSpan.FromSeconds(10);
+        factory.RequestedHeartbeat = TimeSpan.FromSeconds(30);
+
+        // Create connection and channel
+        _connection = await factory.CreateConnectionAsync(cancellationToken);
+        _channel = await _connection.CreateChannelAsync(cancellationToken: cancellationToken);
+
+        // Get RabbitMQ-specific configuration
+        var exchange = config.ProviderSpecific.GetValueOrDefault("Exchange", "apiprojecttemplate.events");
+        var routingKey = config.ProviderSpecific.GetValueOrDefault("RoutingKey", "");
+        var exchangeType = config.ProviderSpecific.GetValueOrDefault("ExchangeType", ExchangeType.Topic);
+
+        // Declare exchange and queue
+        await _channel.ExchangeDeclareAsync(exchange, exchangeType, durable: true, cancellationToken: cancellationToken);
+        await _channel.QueueDeclareAsync(
+            queue: config.Queue,
+            durable: true,
+            exclusive: false,
+            autoDelete: false,
+            arguments: null, cancellationToken: cancellationToken);
+
+        await _channel.QueueBindAsync(
+            queue: config.Queue,
+            exchange: exchange,
+            routingKey: routingKey, cancellationToken: cancellationToken);
+
+        // Set QoS prefetch based on concurrency
+        await _channel.BasicQosAsync(
+            prefetchSize: 0,
+            prefetchCount: (ushort)config.Concurrency,
+            global: false, cancellationToken: cancellationToken);
+
+        // Initialize semaphore for concurrency control
+        _semaphore = new SemaphoreSlim(config.Concurrency, config.Concurrency);
+
+        logger.LogInformation(
+            "RabbitMqBrokerAdapter connected (Queue: {Queue}, Exchange: {Exchange}, Concurrency: {Concurrency})",
+            config.Queue, exchange, config.Concurrency);
+    }
+
+    public async Task SubscribeAsync<TMessage>(
+        Func<TMessage, MessageContext, Task<MessageProcessingResult>> handler,
+        CancellationToken cancellationToken)
+    {
+        if (_channel == null)
+            throw new InvalidOperationException("Channel not initialized. Call ConnectAsync first.");
+
+        if (_semaphore == null)
+            throw new InvalidOperationException("Semaphore not initialized. Call ConnectAsync first.");
+
+        var consumer = new AsyncEventingBasicConsumer(_channel);
+        consumer.ReceivedAsync += async (sender, ea) =>
+        {
+            await _semaphore.WaitAsync(cancellationToken);
+
+            try
+            {
+                // Deserialize message
+                var body = ea.Body.ToArray();
+                var payload = Encoding.UTF8.GetString(body);
+                TMessage? message;
+
+                try
+                {
+                    message = JsonSerializer.Deserialize<TMessage>(payload, _jsonOptions);
+                }
+                catch (JsonException ex)
+                {
+                    logger.LogWarning(ex,
+                        "Failed to deserialize message on queue {Queue}: {Payload}",
+                        _queueName, payload);
+
+                    // ACK invalid messages to prevent reprocessing
+                    await AckMessageAsync(ea.DeliveryTag);
+                    return;
+                }
+
+                if (message == null)
+                {
+                    logger.LogWarning("Deserialized message is null on queue {Queue}", _queueName);
+                    await AckMessageAsync(ea.DeliveryTag);
+                    return;
+                }
+
+                // Create message context
+                var context = new MessageContext
+                {
+                    MessageId = ea.BasicProperties.MessageId ?? ea.DeliveryTag.ToString(),
+                    CorrelationId = ea.BasicProperties.CorrelationId ?? "",
+                    DeliveryCount = ea.Redelivered ? 2 : 1, // RabbitMQ doesn't expose exact count
+                    Headers = ConvertHeaders(ea.BasicProperties?.Headers),
+                    CancellationToken = cancellationToken
+                };
+
+                // Call handler
+                MessageProcessingResult result;
+                try
+                {
+                    result = await handler(message, context);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex,
+                        "Unhandled exception in message handler for queue {Queue}, DeliveryTag {DeliveryTag}",
+                        _queueName, ea.DeliveryTag);
+                    result = MessageProcessingResult.FailedWithException(ex, requeue: false);
+                }
+
+                // Handle result
+                if (result.Success)
+                {
+                    await AckMessageAsync(ea.DeliveryTag);
+                }
+                else
+                {
+                    await NackMessageAsync(ea.DeliveryTag, result.Requeue);
+
+                    logger.LogWarning(
+                        "Message processing failed (Queue: {Queue}, Requeue: {Requeue}, Reason: {Reason})",
+                        _queueName, result.Requeue, result.ErrorReason);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Requeue on cancellation
+                await NackMessageAsync(ea.DeliveryTag, requeue: true);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex,
+                    "Unexpected error processing message (Queue: {Queue}, DeliveryTag: {DeliveryTag})",
+                    _queueName, ea.DeliveryTag);
+
+                // Don't requeue on unexpected errors
+                await NackMessageAsync(ea.DeliveryTag, requeue: false);
+            }
+            finally
+            {
+                _semaphore.Release();
+            }
+        };
+
+        await _channel.BasicConsumeAsync(
+            queue: _queueName!,
+            autoAck: false,
+            consumer: consumer,
+            cancellationToken: cancellationToken);
+
+        logger.LogInformation("RabbitMqBrokerAdapter subscribed to queue {Queue}", _queueName);
+    }
+
+    public async Task DisconnectAsync()
+    {
+        try
+        {
+            if (_channel != null)
+            {
+                await _channel.CloseAsync();
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Error closing channel");
+        }
+
+        try
+        {
+            if (_connection != null)
+            {
+                await _connection.CloseAsync();
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Error closing connection");
+        }
+
+        logger.LogInformation("RabbitMqBrokerAdapter disconnected");
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await DisconnectAsync();
+
+        _semaphore?.Dispose();
+        _channelLock.Dispose();
+
+        try { _channel?.Dispose(); } catch { }
+        try { _connection?.Dispose(); } catch { }
+
+        GC.SuppressFinalize(this);
+    }
+
+    // Private helper methods
+
+    private async Task AckMessageAsync(ulong deliveryTag)
+    {
+        await _channelLock.WaitAsync();
+        try
+        {
+            await _channel!.BasicAckAsync(deliveryTag, multiple: false);
+        }
+        finally
+        {
+            _channelLock.Release();
+        }
+    }
+
+    private async Task NackMessageAsync(ulong deliveryTag, bool requeue)
+    {
+        await _channelLock.WaitAsync();
+        try
+        {
+            await _channel!.BasicNackAsync(deliveryTag, multiple: false, requeue: requeue);
+        }
+        catch { }
+        finally
+        {
+            _channelLock.Release();
+        }
+    }
+
+    private static IReadOnlyDictionary<string, object> ConvertHeaders(IDictionary<string, object?>? headers)
+    {
+        if (headers == null || headers.Count == 0)
+            return new Dictionary<string, object>();
+
+        var result = new Dictionary<string, object>();
+        foreach (var header in headers)
+        {
+            if (header.Value != null)
+            {
+                // Convert byte[] headers to strings
+                if (header.Value is byte[] bytes)
+                {
+                    result[header.Key] = Encoding.UTF8.GetString(bytes);
+                }
+                else
+                {
+                    result[header.Key] = header.Value;
+                }
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/Api.Project.Template.Infrastructure/Messaging/RabbitMq/RabbitMqConnectionStringParser.cs
+++ b/src/Api.Project.Template.Infrastructure/Messaging/RabbitMq/RabbitMqConnectionStringParser.cs
@@ -1,0 +1,60 @@
+using RabbitMQ.Client;
+
+namespace Api.Project.Template.Infrastructure.Messaging.RabbitMq;
+
+/// <summary>
+/// Parses RabbitMQ connection strings into a <see cref="ConnectionFactory"/>.
+/// Supports both URI format (amqp://user:pass@host:port/vhost) and
+/// key-value format (Host=localhost;Username=guest;Password=guest).
+/// </summary>
+internal static class RabbitMqConnectionStringParser
+{
+    public static ConnectionFactory Parse(string connectionString)
+    {
+        var factory = new ConnectionFactory();
+
+        if (Uri.TryCreate(connectionString, UriKind.Absolute, out var uri) &&
+            (uri.Scheme == "amqp" || uri.Scheme == "amqps"))
+        {
+            factory.Uri = uri;
+        }
+        else
+        {
+            var parts = connectionString.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            foreach (var part in parts)
+            {
+                var kv = part.Split('=', 2);
+                if (kv.Length != 2) continue;
+
+                var key = kv[0].Trim().ToLowerInvariant();
+                var value = kv[1].Trim();
+
+                switch (key)
+                {
+                    case "host":
+                    case "hostname":
+                        factory.HostName = value;
+                        break;
+                    case "username":
+                    case "user":
+                        factory.UserName = value;
+                        break;
+                    case "password":
+                    case "pwd":
+                        factory.Password = value;
+                        break;
+                    case "virtualhost":
+                    case "vhost":
+                        factory.VirtualHost = value;
+                        break;
+                    case "port":
+                        if (int.TryParse(value, out var port))
+                            factory.Port = port;
+                        break;
+                }
+            }
+        }
+
+        return factory;
+    }
+}

--- a/src/Api.Project.Template.Infrastructure/Messaging/RabbitMq/RabbitMqMessagePublisher.cs
+++ b/src/Api.Project.Template.Infrastructure/Messaging/RabbitMq/RabbitMqMessagePublisher.cs
@@ -1,0 +1,315 @@
+using Api.Project.Template.Application.Abstractions.Logging;
+using Api.Project.Template.Application.Messaging;
+using Api.Project.Template.Application.Messaging.Abstractions;
+using Microsoft.Extensions.Configuration;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Exceptions;
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+
+namespace Api.Project.Template.Infrastructure.Messaging.RabbitMq;
+
+public class RabbitMqMessagePublisher : IMessagePublisher, IAsyncDisposable, IDisposable
+{
+    private readonly ConnectionFactory _factory;
+    private IConnection? _connection;
+    private readonly ILoggerAdapter<RabbitMqMessagePublisher> _logger;
+    private readonly JsonSerializerOptions _jsonOptions;
+    private readonly string _exchange;
+    private readonly SemaphoreSlim _connectionLock = new(1, 1);
+    private readonly int _maxPublishRetries;
+    private readonly TimeSpan _initialRetryDelay;
+
+    // Channel pooling for performance optimization (Phase 2)
+    private IChannel? _publishChannel;
+    private readonly SemaphoreSlim _publishLock = new(1, 1);
+
+    public RabbitMqMessagePublisher(IConfiguration configuration, ILoggerAdapter<RabbitMqMessagePublisher> logger)
+    {
+        _logger = logger;
+
+        // serialization options
+        _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+            WriteIndented = false
+        };
+
+        // read configuration (support several shapes used by Aspire)
+        string? connectionString =
+            configuration["MessageBus:RabbitMq:ConnectionString"]
+            ?? configuration["MessageBus:RabbitMq"]
+            ?? configuration["MessageBus__RabbitMq__ConnectionString"]
+            ?? configuration["MessageBus__RabbitMq"]
+            ?? configuration.GetConnectionString("RabbitMq")
+            ?? configuration.GetConnectionString("messaging");
+
+        if (string.IsNullOrWhiteSpace(connectionString))
+            throw new InvalidOperationException("RabbitMQ connection string not configured. Set MessageBus:RabbitMq or ConnectionStrings:RabbitMq.");
+
+        _factory = RabbitMqConnectionStringParser.Parse(connectionString);
+
+        // resilience settings
+        _factory.AutomaticRecoveryEnabled = true;
+        _factory.TopologyRecoveryEnabled = true;
+        _factory.NetworkRecoveryInterval = TimeSpan.FromSeconds(10);
+        _factory.RequestedHeartbeat = TimeSpan.FromSeconds(30);
+
+        // publish defaults - tune via config if desired
+        _exchange = configuration["MessageBus:Exchange"] ?? configuration["MessageBus__Exchange"] ?? "apiprojecttemplate.events";
+        _maxPublishRetries = int.TryParse(configuration["MessageBus:Publish:MaxRetries"], out var mr) ? mr : 3;
+        _initialRetryDelay = TimeSpan.FromMilliseconds(int.TryParse(configuration["MessageBus:Publish:InitialDelayMs"], out var id) ? id : 200);
+
+        _logger.LogInformation("RabbitMqMessagePublisher configured for exchange {Exchange}", _exchange);
+    }
+
+    private async Task EnsureConnectedAsync()
+    {
+        if (_connection is { IsOpen: true }) return;
+
+        await _connectionLock.WaitAsync();
+        try
+        {
+            if (_connection is { IsOpen: true }) return;
+
+            _logger.LogInformation("Creating RabbitMQ connection...");
+
+            // CreateConnectionAsync can throw; allow caller to handle/log and possibly retry.
+            _connection = await _factory.CreateConnectionAsync();
+
+            _logger.LogInformation("RabbitMQ connection established (node: {Node})", _connection.Endpoint.HostName);
+
+            // Ensure exchange exists using a short-lived channel
+            var channel = await _connection.CreateChannelAsync();
+            try
+            {
+                await channel.ExchangeDeclareAsync(_exchange, ExchangeType.Topic, durable: true);
+            }
+            finally
+            {
+                await channel.DisposeAsync();
+            }
+        }
+        finally
+        {
+            _connectionLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Ensures a dedicated publish channel is available for message publishing.
+    /// Channel creation uses lock-free double-checked pattern for performance.
+    /// The actual channel usage is protected by _publishLock in PublishAsync.
+    /// </summary>
+    private async Task EnsurePublishChannelAsync(CancellationToken cancellationToken = default)
+    {
+        // Fast path: channel exists and is open
+        if (_publishChannel is { IsOpen: true })
+            return;
+
+        // Slow path: need to create channel (only happens once, or after connection loss)
+        // Use Interlocked pattern for lock-free channel creation
+        var currentChannel = _publishChannel;
+        if (currentChannel is not { IsOpen: true })
+        {
+            // Close existing channel if it exists but is not open
+            if (currentChannel != null)
+            {
+                try { await currentChannel.CloseAsync(cancellationToken); } catch { }
+                try { currentChannel.Dispose(); } catch { }
+            }
+
+            _logger.LogInformation("Creating dedicated RabbitMQ publisher channel...");
+            var newChannel = await _connection!.CreateChannelAsync(cancellationToken: cancellationToken);
+
+            // Atomic swap - if another thread created a channel, use theirs and dispose ours
+            var originalChannel = Interlocked.CompareExchange(ref _publishChannel, newChannel, currentChannel);
+            if (originalChannel != currentChannel && originalChannel is { IsOpen: true })
+            {
+                try { await newChannel.CloseAsync(cancellationToken); } catch { }
+                try { newChannel.Dispose(); } catch { }
+                _logger.LogInformation("Another thread created the channel first, using theirs");
+            }
+            else
+            {
+                _logger.LogInformation("Publisher channel created and ready for use");
+            }
+        }
+    }
+
+    public async Task PublishAsync<T>(T message, MessagePublishOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        if (message is null) throw new ArgumentNullException(nameof(message));
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var ex = options?.Destination ?? _exchange;
+        var rk = options?.Subject ?? typeof(T).Name;
+
+        // Serialize message BEFORE acquiring lock (minimize lock duration)
+        var payload = JsonSerializer.Serialize(message, _jsonOptions);
+        var body = Encoding.UTF8.GetBytes(payload);
+
+        // Prepare message properties BEFORE acquiring lock
+        var correlationId = Activity.Current?.Tags.FirstOrDefault(t => t.Key == "client.correlation_id").Value
+                            ?? Activity.Current?.Baggage.FirstOrDefault(kv => kv.Key == "client.correlation_id").Value
+                            ?? Activity.Current?.TraceId.ToString()
+                            ?? Activity.Current?.Id
+                            ?? Guid.NewGuid().ToString();
+
+        var props = new BasicProperties
+        {
+            ContentType = "application/json",
+            DeliveryMode = DeliveryModes.Persistent,
+            CorrelationId = correlationId,
+            Headers = new Dictionary<string, object?>
+            {
+                ["correlation-id"] = Encoding.UTF8.GetBytes(correlationId),
+                ["message-type"] = Encoding.UTF8.GetBytes(typeof(T).FullName ?? typeof(T).Name)
+            },
+            Timestamp = new AmqpTimestamp(DateTimeOffset.UtcNow.ToUnixTimeSeconds())
+        };
+
+        var attempt = 0;
+        var delay = _initialRetryDelay;
+
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            attempt++;
+
+            try
+            {
+                await EnsureConnectedAsync();
+                await EnsurePublishChannelAsync(cancellationToken);
+
+                // Acquire lock to use the shared channel (channels are NOT thread-safe)
+                await _publishLock.WaitAsync(cancellationToken);
+                try
+                {
+                    await _publishChannel!.BasicPublishAsync(
+                        exchange: ex,
+                        routingKey: rk,
+                        mandatory: false,
+                        basicProperties: props,
+                        body: body,
+                        cancellationToken: cancellationToken);
+                }
+                finally
+                {
+                    _publishLock.Release();
+                }
+
+                _logger.LogInformation("Published message {Type} to exchange {Exchange} with routing key {RoutingKey}", typeof(T).Name, ex, rk);
+                return;
+            }
+            catch (OperationInterruptedException oex)
+            {
+                _logger.LogWarning(oex, "Transient RabbitMQ interruption while publishing message {Type} attempt {Attempt}", typeof(T).Name, attempt);
+
+                if (attempt >= _maxPublishRetries)
+                    throw;
+
+                await Task.Delay(delay, cancellationToken);
+                delay = TimeSpan.FromMilliseconds(Math.Min(delay.TotalMilliseconds * 2, 5000));
+                // connection may be in an error state – dispose and allow recreation on next loop
+                await SafeCloseConnectionAsync();
+            }
+            catch (BrokerUnreachableException bue)
+            {
+                _logger.LogWarning(bue, "Broker unreachable while publishing message {Type} attempt {Attempt}", typeof(T).Name, attempt);
+
+                if (attempt >= _maxPublishRetries)
+                    throw;
+
+                await Task.Delay(delay, cancellationToken);
+                delay = TimeSpan.FromMilliseconds(Math.Min(delay.TotalMilliseconds * 2, 5000));
+                await SafeCloseConnectionAsync();
+            }
+            catch (Exception exn)
+            {
+                _logger.LogError(exn, "Failed to publish message {Type} attempt {Attempt}", typeof(T).Name, attempt);
+                // If last attempt, rethrow; otherwise back off and retry
+                if (attempt >= _maxPublishRetries)
+                    throw;
+
+                await Task.Delay(delay, cancellationToken);
+                delay = TimeSpan.FromMilliseconds(Math.Min(delay.TotalMilliseconds * 2, 5000));
+                await SafeCloseConnectionAsync();
+            }
+        }
+    }
+
+    private async Task SafeCloseConnectionAsync()
+    {
+        try
+        {
+            // Close publish channel first
+            if (_publishChannel is not null)
+            {
+                try
+                {
+                    if (_publishChannel.IsOpen)
+                    {
+                        await _publishChannel.CloseAsync();
+                    }
+                    _publishChannel.Dispose();
+                }
+                catch { /* swallow */ }
+                finally
+                {
+                    _publishChannel = null;
+                }
+            }
+
+            // Then close connection
+            if (_connection is not null)
+            {
+                if (_connection.IsOpen)
+                {
+                    try { await _connection.CloseAsync(); } catch { }
+                }
+
+                _connection.Dispose();
+            }
+        }
+        catch { /* swallow */ }
+        finally
+        {
+            _connection = null;
+        }
+    }
+
+    /// <summary>
+    /// Disposes resources asynchronously. Prefer this over Dispose() to avoid potential deadlocks.
+    /// </summary>
+    public async ValueTask DisposeAsync()
+    {
+        await SafeCloseConnectionAsync();
+        _connectionLock.Dispose();
+        _publishLock.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Synchronous disposal. Note: This blocks on async cleanup which may cause issues in some contexts.
+    /// Prefer DisposeAsync() when possible.
+    /// </summary>
+    public void Dispose()
+    {
+        // We must block here since IDisposable.Dispose is synchronous
+        // This is safe in most contexts but could deadlock in ASP.NET synchronization contexts
+        // Callers should prefer DisposeAsync when possible
+        try
+        {
+            SafeCloseConnectionAsync().GetAwaiter().GetResult();
+        }
+        finally
+        {
+            _connectionLock.Dispose();
+            _publishLock.Dispose();
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/src/Api.Project.Template.Infrastructure/Messaging/RoutingMessagePublisher.cs
+++ b/src/Api.Project.Template.Infrastructure/Messaging/RoutingMessagePublisher.cs
@@ -1,0 +1,151 @@
+using Api.Project.Template.Application.Abstractions.Logging;
+using Api.Project.Template.Application.Messaging;
+using Api.Project.Template.Application.Messaging.Abstractions;
+using Microsoft.Extensions.Options;
+using System.Collections.Concurrent;
+
+namespace Api.Project.Template.Infrastructure.Messaging;
+
+/// <summary>
+/// Decorator for IMessagePublisher that applies message-type-based routing configuration.
+/// Resolves routing from configuration and delegates to inner publisher.
+/// </summary>
+public class RoutingMessagePublisher : IMessagePublisher, IAsyncDisposable
+{
+    private readonly IMessagePublisher _innerPublisher;
+    private readonly MessageRoutingConfig _routingConfig;
+    private readonly ILoggerAdapter<RoutingMessagePublisher> _logger;
+
+    // Cache resolved routing to avoid repeated lookups
+    private readonly ConcurrentDictionary<Type, MessagePublishOptions> _routingCache = new();
+
+    public RoutingMessagePublisher(
+        IMessagePublisher innerPublisher,
+        IOptions<MessageRoutingConfig> routingConfig,
+        ILoggerAdapter<RoutingMessagePublisher> logger)
+    {
+        _innerPublisher = innerPublisher ?? throw new ArgumentNullException(nameof(innerPublisher));
+        _routingConfig = routingConfig?.Value ?? throw new ArgumentNullException(nameof(routingConfig));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        _logger.LogInformation(
+            "RoutingMessagePublisher initialized with provider: {Provider}, Routes: {RouteCount}",
+            _routingConfig.Provider,
+            _routingConfig.Routes.Count);
+    }
+
+    public async Task PublishAsync<T>(
+        T message,
+        MessagePublishOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (message is null)
+            throw new ArgumentNullException(nameof(message));
+
+        // If caller provided explicit destination, respect it (override routing config)
+        if (options is { Destination: not null })
+        {
+            _logger.LogDebug(
+                "Publishing {MessageType} with explicit destination: {Destination}",
+                typeof(T).Name,
+                options.Destination);
+
+            await _innerPublisher.PublishAsync(message, options, cancellationToken);
+            return;
+        }
+
+        // Resolve routing from configuration (cached)
+        var resolvedOptions = GetOrCreateRoutingOptions<T>(options);
+
+        _logger.LogDebug(
+            "Publishing {MessageType} to {Destination} with routing key {RoutingKey}",
+            typeof(T).Name,
+            resolvedOptions.Destination,
+            resolvedOptions.Subject);
+
+        await _innerPublisher.PublishAsync(message, resolvedOptions, cancellationToken);
+    }
+
+    private MessagePublishOptions GetOrCreateRoutingOptions<T>(MessagePublishOptions? userOptions)
+    {
+        return _routingCache.GetOrAdd(typeof(T), _ =>
+        {
+            var messageTypeName = typeof(T).Name;
+
+            // Try to find route config for this message type
+            if (_routingConfig.Routes.TryGetValue(messageTypeName, out var route))
+            {
+                _logger.LogDebug(
+                    "Resolved routing for {MessageType}: Destination={Destination}, RoutingKey={RoutingKey}",
+                    messageTypeName,
+                    route.Destination ?? _routingConfig.DefaultDestination,
+                    route.RoutingKey ?? route.Subject ?? _routingConfig.DefaultRoutingKey ?? messageTypeName);
+
+                return new MessagePublishOptions
+                {
+                    Destination = route.Destination ?? _routingConfig.DefaultDestination,
+                    Subject = route.RoutingKey ?? route.Subject ?? _routingConfig.DefaultRoutingKey ?? messageTypeName,
+                    Metadata = MergeMetadata(userOptions?.Metadata, route.Metadata)
+                };
+            }
+
+            // Fallback to defaults
+            _logger.LogWarning(
+                "No routing configuration found for {MessageType}, using defaults (Destination={Destination}, RoutingKey={RoutingKey})",
+                messageTypeName,
+                _routingConfig.DefaultDestination ?? "(null)",
+                _routingConfig.DefaultRoutingKey ?? messageTypeName);
+
+            return new MessagePublishOptions
+            {
+                Destination = _routingConfig.DefaultDestination,
+                Subject = _routingConfig.DefaultRoutingKey ?? messageTypeName,
+                Metadata = userOptions?.Metadata
+            };
+        });
+    }
+
+    private static IDictionary<string, object>? MergeMetadata(
+        IDictionary<string, object>? userMetadata,
+        Dictionary<string, string>? routeMetadata)
+    {
+        if (userMetadata == null && routeMetadata == null)
+            return null;
+
+        var merged = new Dictionary<string, object>();
+
+        // Add route metadata first (lower priority)
+        if (routeMetadata != null)
+        {
+            foreach (var kvp in routeMetadata)
+            {
+                merged[kvp.Key] = kvp.Value;
+            }
+        }
+
+        // Add user metadata (higher priority, overrides route metadata)
+        if (userMetadata != null)
+        {
+            foreach (var kvp in userMetadata)
+            {
+                merged[kvp.Key] = kvp.Value;
+            }
+        }
+
+        return merged.Count > 0 ? merged : null;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_innerPublisher is IAsyncDisposable asyncDisposable)
+        {
+            await asyncDisposable.DisposeAsync();
+        }
+        else if (_innerPublisher is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
+
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/Api.Project.Template.Infrastructure/Messaging/ServiceBus/ServiceBusBrokerAdapter.cs
+++ b/src/Api.Project.Template.Infrastructure/Messaging/ServiceBus/ServiceBusBrokerAdapter.cs
@@ -1,0 +1,235 @@
+using Api.Project.Template.Application.Abstractions.Logging;
+using Api.Project.Template.Application.Messaging;
+using Api.Project.Template.Infrastructure.Messaging.Abstractions;
+using Azure.Messaging.ServiceBus;
+using System.Text;
+using System.Text.Json;
+
+namespace Api.Project.Template.Infrastructure.Messaging.ServiceBus;
+
+/// <summary>
+/// Azure Service Bus implementation of IMessageBrokerAdapter.
+/// Wraps Azure.Messaging.ServiceBus APIs to provide a consistent interface for message consumption.
+/// </summary>
+public class ServiceBusBrokerAdapter(ILoggerAdapter<ServiceBusBrokerAdapter> logger) : IMessageBrokerAdapter
+{
+    private readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+
+    private ServiceBusClient? _client;
+    private ServiceBusProcessor? _processor;
+    private string? _queueName;
+    private int _maxRetries;
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// For Azure Service Bus, this method creates the <see cref="ServiceBusClient"/> and configures
+    /// the <see cref="ServiceBusProcessor"/>, but does NOT open a connection to the broker.
+    /// The underlying connection is deferred to <see cref="SubscribeAsync{TMessage}"/>, which calls
+    /// <c>ServiceBusProcessor.StartProcessingAsync</c> — the first point at which the SDK connects.
+    /// This is an SDK constraint: <see cref="ServiceBusProcessor"/> has no standalone connect method.
+    /// </remarks>
+    public async Task ConnectAsync(MessageBrokerConfig config, CancellationToken cancellationToken)
+    {
+        _queueName = config.Queue;
+        _maxRetries = config.MaxRetries;
+
+        _client = new ServiceBusClient(config.ConnectionString);
+
+        _processor = _client.CreateProcessor(
+            config.Queue,
+            new ServiceBusProcessorOptions
+            {
+                AutoCompleteMessages = false,
+                MaxConcurrentCalls = config.Concurrency,
+                PrefetchCount = config.PrefetchCount
+            });
+
+        logger.LogInformation(
+            "ServiceBusBrokerAdapter configured (Queue: {Queue}, Concurrency: {Concurrency}) — connection deferred to SubscribeAsync",
+            config.Queue, config.Concurrency);
+
+        await Task.CompletedTask;
+    }
+
+    public async Task SubscribeAsync<TMessage>(
+        Func<TMessage, MessageContext, Task<MessageProcessingResult>> handler,
+        CancellationToken cancellationToken)
+    {
+        if (_processor == null)
+            throw new InvalidOperationException("Must call ConnectAsync before SubscribeAsync");
+
+        // Wire up message handler
+        _processor.ProcessMessageAsync += async args =>
+        {
+            try
+            {
+                // Deserialize message
+                var body = Encoding.UTF8.GetString(args.Message.Body);
+                TMessage? message;
+
+                try
+                {
+                    message = JsonSerializer.Deserialize<TMessage>(body, _jsonOptions);
+                }
+                catch (JsonException ex)
+                {
+                    logger.LogWarning(ex,
+                        "Failed to deserialize message on queue {Queue}: {Body}",
+                        _queueName, body);
+
+                    // Dead-letter invalid messages
+                    await args.DeadLetterMessageAsync(args.Message, "DeserializationFailed", ex.Message, cancellationToken);
+                    return;
+                }
+
+                if (message == null)
+                {
+                    logger.LogWarning("Deserialized message is null on queue {Queue}", _queueName);
+                    await args.DeadLetterMessageAsync(args.Message, "NullMessage", "Message deserialized to null", cancellationToken);
+                    return;
+                }
+
+                // Create message context
+                var context = new MessageContext
+                {
+                    MessageId = args.Message.MessageId,
+                    CorrelationId = args.Message.CorrelationId ?? "",
+                    DeliveryCount = args.Message.DeliveryCount,
+                    Headers = ConvertApplicationProperties(args.Message.ApplicationProperties),
+                    CancellationToken = args.CancellationToken
+                };
+
+                // Call handler
+                MessageProcessingResult result;
+                try
+                {
+                    result = await handler(message, context);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex,
+                        "Unhandled exception in message handler for queue {Queue}, MessageId {MessageId}",
+                        _queueName, args.Message.MessageId);
+                    result = MessageProcessingResult.FailedWithException(ex, requeue: false);
+                }
+
+                // Handle result
+                if (result.Success)
+                {
+                    await args.CompleteMessageAsync(args.Message, cancellationToken);
+                }
+                else
+                {
+                    // Check if we've exceeded max retries
+                    if (args.Message.DeliveryCount >= _maxRetries)
+                    {
+                        logger.LogWarning(
+                            "Message exceeded max retries (Queue: {Queue}, MessageId: {MessageId}, DeliveryCount: {DeliveryCount})",
+                            _queueName, args.Message.MessageId, args.Message.DeliveryCount);
+
+                        await args.DeadLetterMessageAsync(
+                            args.Message,
+                            "MaxRetriesExceeded",
+                            result.ErrorReason ?? "Processing failed after maximum retries", cancellationToken);
+                    }
+                    else if (result.Requeue)
+                    {
+                        // Abandon to requeue
+                        await args.AbandonMessageAsync(args.Message, cancellationToken: cancellationToken);
+
+                        logger.LogWarning(
+                            "Message processing failed, requeuing (Queue: {Queue}, MessageId: {MessageId}, Reason: {Reason})",
+                            _queueName, args.Message.MessageId, result.ErrorReason);
+                    }
+                    else
+                    {
+                        // Dead-letter without retrying
+                        await args.DeadLetterMessageAsync(
+                            args.Message,
+                            "ProcessingFailed",
+                            result.ErrorReason ?? "Processing failed", cancellationToken);
+
+                        logger.LogWarning(
+                            "Message processing failed, dead-lettered (Queue: {Queue}, MessageId: {MessageId}, Reason: {Reason})",
+                            _queueName, args.Message.MessageId, result.ErrorReason);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex,
+                    "Unexpected error processing message (Queue: {Queue}, MessageId: {MessageId})",
+                    _queueName, args.Message.MessageId);
+
+                // Dead-letter on unexpected errors
+                try
+                {
+                    await args.DeadLetterMessageAsync(args.Message, "UnexpectedError", ex.Message, cancellationToken);
+                }
+                catch (Exception deadLetterEx)
+                {
+                    logger.LogError(deadLetterEx, "Failed to dead-letter message {MessageId}", args.Message.MessageId);
+                }
+            }
+        };
+
+        // Wire up error handler
+        _processor.ProcessErrorAsync += async args =>
+        {
+            logger.LogError(args.Exception,
+                "Service Bus error: {ErrorSource}, Entity: {EntityPath}",
+                args.ErrorSource,
+                args.EntityPath);
+
+            await Task.CompletedTask;
+        };
+
+        // Start processing
+        await _processor.StartProcessingAsync(cancellationToken);
+
+        logger.LogInformation("ServiceBusBrokerAdapter subscribed to queue {Queue}", _queueName);
+    }
+
+    public async Task DisconnectAsync()
+    {
+        if (_processor != null)
+        {
+            try
+            {
+                await _processor.StopProcessingAsync();
+                logger.LogInformation("ServiceBusBrokerAdapter disconnected from queue {Queue}", _queueName);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Error stopping processor");
+            }
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await DisconnectAsync();
+
+        if (_processor != null)
+        {
+            await _processor.DisposeAsync();
+        }
+
+        if (_client != null)
+        {
+            await _client.DisposeAsync();
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    private static IReadOnlyDictionary<string, object> ConvertApplicationProperties(
+        IReadOnlyDictionary<string, object> applicationProperties)
+    {
+        return new Dictionary<string, object>(applicationProperties);
+    }
+}

--- a/src/Api.Project.Template.Infrastructure/Messaging/ServiceBus/ServiceBusMessagePublisher.cs
+++ b/src/Api.Project.Template.Infrastructure/Messaging/ServiceBus/ServiceBusMessagePublisher.cs
@@ -1,0 +1,111 @@
+using Api.Project.Template.Application.Abstractions.Logging;
+using Api.Project.Template.Application.Messaging;
+using Api.Project.Template.Application.Messaging.Abstractions;
+using Azure.Messaging.ServiceBus;
+using Microsoft.Extensions.Configuration;
+using System.Collections.Concurrent;
+using System.Text;
+using System.Text.Json;
+
+namespace Api.Project.Template.Infrastructure.Messaging.ServiceBus;
+
+/// <summary>
+/// Azure Service Bus implementation of IMessagePublisher.
+/// Supports both emulator (local dev) and cloud (production).
+/// </summary>
+public class ServiceBusMessagePublisher : IMessagePublisher, IAsyncDisposable
+{
+    private readonly ServiceBusClient _client;
+    private readonly ILoggerAdapter<ServiceBusMessagePublisher> _logger;
+    private readonly JsonSerializerOptions _jsonOptions;
+    private readonly string _defaultQueue;
+    private readonly ConcurrentDictionary<string, ServiceBusSender> _senders = new();
+
+    public ServiceBusMessagePublisher(
+        IConfiguration configuration,
+        ILoggerAdapter<ServiceBusMessagePublisher> logger)
+    {
+        _logger = logger;
+
+        // Read connection string (Aspire injects this automatically)
+        var connectionString =
+            configuration["ConnectionStrings:servicebus"]
+            ?? configuration.GetConnectionString("servicebus")
+            ?? throw new InvalidOperationException(
+                "Azure Service Bus connection string not configured. " +
+                "Set ConnectionStrings:servicebus in configuration.");
+
+        _client = new ServiceBusClient(connectionString);
+
+        _defaultQueue = configuration["ServiceBus:DefaultQueue"] ?? "sample-requests";
+
+        _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+            WriteIndented = false
+        };
+
+        _logger.LogInformation(
+            "ServiceBusMessagePublisher configured for queue {Queue}",
+            _defaultQueue);
+    }
+
+    public async Task PublishAsync<T>(
+        T message,
+        MessagePublishOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (message is null)
+            throw new ArgumentNullException(nameof(message));
+
+        var queueName = options?.Destination ?? _defaultQueue;
+
+        // Serialize message
+        var payload = JsonSerializer.Serialize(message, _jsonOptions);
+        var body = new BinaryData(Encoding.UTF8.GetBytes(payload));
+
+        // Create Service Bus message
+        var sbMessage = new ServiceBusMessage(body)
+        {
+            ContentType = "application/json",
+            MessageId = Guid.NewGuid().ToString(),
+            Subject = options?.Subject ?? typeof(T).Name
+        };
+
+        // Add metadata
+        sbMessage.ApplicationProperties["MessageType"] = typeof(T).FullName ?? typeof(T).Name;
+        sbMessage.ApplicationProperties["Timestamp"] = DateTimeOffset.UtcNow.ToString("O");
+
+        // Send message — sender is cached and reused across calls to the same queue
+        var sender = _senders.GetOrAdd(queueName, _client.CreateSender);
+
+        try
+        {
+            await sender.SendMessageAsync(sbMessage, cancellationToken);
+
+            _logger.LogInformation(
+                "Published message {MessageType} to queue {Queue} (MessageId: {MessageId})",
+                typeof(T).Name,
+                queueName,
+                sbMessage.MessageId);
+        }
+        catch (ServiceBusException ex)
+        {
+            _logger.LogError(ex,
+                "Failed to publish message {MessageType} to queue {Queue}",
+                typeof(T).Name,
+                queueName);
+            throw;
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var sender in _senders.Values)
+            await sender.DisposeAsync();
+
+        await _client.DisposeAsync();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/Api.Project.Template.Worker/Api.Project.Template.Worker.csproj
+++ b/src/Api.Project.Template.Worker/Api.Project.Template.Worker.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <UserSecretsId>b1a2c3d4-e5f6-7890-abcd-ef1234567890</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+	<PackageReference Include="Aspire.RabbitMQ.Client" />
+	<PackageReference Include="Serilog.AspNetCore" />
+	<PackageReference Include="Serilog.Enrichers.Environment" />
+	<PackageReference Include="Serilog.Enrichers.Process" />
+	<PackageReference Include="Serilog.Enrichers.Thread" />
+	<PackageReference Include="Serilog.Sinks.Console" />
+	<PackageReference Include="Serilog.Sinks.OpenTelemetry" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Api.Project.Template.Application\Api.Project.Template.Application.csproj" />
+    <ProjectReference Include="..\Api.Project.Template.Infrastructure\Api.Project.Template.Infrastructure.csproj" />
+    <ProjectReference Include="..\Api.Project.Template.ServiceDefaults\Api.Project.Template.ServiceDefaults.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Api.Project.Template.Worker/Program.cs
+++ b/src/Api.Project.Template.Worker/Program.cs
@@ -1,0 +1,49 @@
+using Api.Project.Template.Application.Abstractions.Logging;
+using Api.Project.Template.Infrastructure.Logging;
+using Api.Project.Template.Infrastructure.Messaging;
+using Api.Project.Template.ServiceDefaults;
+using Api.Project.Template.Worker;
+using Serilog;
+
+var builder = Host.CreateApplicationBuilder(args);
+builder.AddServiceDefaults();
+
+Log.Logger = new LoggerConfiguration()
+    .ReadFrom.Configuration(builder.Configuration)
+    .Enrich.FromLogContext()
+    .CreateLogger();
+
+builder.Logging.ClearProviders();
+builder.Logging.AddSerilog(Log.Logger);
+
+builder.Services.AddSingleton(typeof(ILoggerAdapter<>), typeof(LoggerAdapter<>));
+
+var messagingProvider = builder.Configuration["MessagingProvider"] ?? "None";
+
+if (messagingProvider == "RabbitMq")
+{
+    builder.AddRabbitMQClient(connectionName: "messaging");
+    builder.Services.AddMessageBus(builder.Configuration);
+    builder.Services.AddMessageConsumer<WeatherRequested, WeatherRequestProcessor, Worker>();
+}
+else if (messagingProvider == "ServiceBus")
+{
+    builder.Services.AddMessageBus(builder.Configuration);
+    builder.Services.AddMessageConsumer<WeatherRequested, WeatherRequestProcessor, Worker>();
+}
+
+try
+{
+    Log.Information("Starting Api.Project.Template.Worker");
+    var host = builder.Build();
+    host.Run();
+}
+catch (Exception ex)
+{
+    Log.Fatal(ex, "Host terminated unexpectedly");
+    throw;
+}
+finally
+{
+    Log.CloseAndFlush();
+}

--- a/src/Api.Project.Template.Worker/WeatherRequestProcessor.cs
+++ b/src/Api.Project.Template.Worker/WeatherRequestProcessor.cs
@@ -1,0 +1,18 @@
+using Api.Project.Template.Application.Abstractions.Logging;
+using Api.Project.Template.Application.Messaging;
+using Api.Project.Template.Application.Messaging.Abstractions;
+
+namespace Api.Project.Template.Worker;
+
+public class WeatherRequestProcessor(ILoggerAdapter<WeatherRequestProcessor> logger)
+    : IMessageProcessor<WeatherRequested>
+{
+    public Task<MessageProcessingResult> ProcessAsync(WeatherRequested message, MessageContext context)
+    {
+        logger.LogInformation(
+            "Processing WeatherRequested: Page={Page}, Size={Size}, RequestedAt={RequestedAt} (MessageId={MessageId})",
+            message.Page, message.Size, message.RequestedAt, context.MessageId);
+
+        return Task.FromResult(MessageProcessingResult.Succeeded());
+    }
+}

--- a/src/Api.Project.Template.Worker/WeatherRequested.cs
+++ b/src/Api.Project.Template.Worker/WeatherRequested.cs
@@ -1,0 +1,10 @@
+namespace Api.Project.Template.Worker;
+
+/// <summary>
+/// Message published by the API when a weather forecast query is executed.
+/// Shape must match WeatherForecastRequestedEvent in the Application layer.
+/// </summary>
+public record WeatherRequested(
+    int Page,
+    int Size,
+    DateTimeOffset RequestedAt);

--- a/src/Api.Project.Template.Worker/Worker.cs
+++ b/src/Api.Project.Template.Worker/Worker.cs
@@ -1,0 +1,10 @@
+using Api.Project.Template.Application.Abstractions.Logging;
+using Api.Project.Template.Infrastructure.Messaging;
+using Api.Project.Template.Infrastructure.Messaging.Abstractions;
+
+namespace Api.Project.Template.Worker;
+
+public sealed class Worker(
+    IMessageConsumer consumer,
+    ILoggerAdapter<MessageConsumerWorker<WeatherRequested, WeatherRequestProcessor>> logger)
+    : MessageConsumerWorker<WeatherRequested, WeatherRequestProcessor>(consumer, logger);

--- a/src/Api.Project.Template.Worker/appsettings.json
+++ b/src/Api.Project.Template.Worker/appsettings.json
@@ -1,0 +1,53 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "MessagingProvider": "RabbitMq",
+  "MessageBus": {
+    "Consumer": {
+      "Queue": "weather-requests",
+      "Concurrency": 5,
+      "MaxRetries": 3,
+      "PrefetchCount": 10
+    },
+    "RabbitMq": {
+      "Exchange": "apiprojecttemplate.events",
+      "RoutingKey": "WeatherRequested",
+      "ExchangeType": "topic"
+    }
+  },
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "System": "Warning",
+        "Microsoft": "Warning",
+        "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
+      }
+    },
+    "Properties": {
+      "Application": "Api.ProjectTemplate.Worker"
+    },
+    "Enrich": [
+      "FromLogContext",
+      "WithMachineName",
+      "WithProcessId",
+      "WithThreadId"
+    ],
+    "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.OpenTelemetry" ],
+    "WriteTo": [
+      {
+        "Name": "Console",
+        "Args": {
+          "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}"
+        }
+      },
+      {
+        "Name": "OpenTelemetry"
+      }
+    ]
+  }
+}

--- a/tests/Api.Project.Template.Tests.Integration/CustomWebApplicationFactory.cs
+++ b/tests/Api.Project.Template.Tests.Integration/CustomWebApplicationFactory.cs
@@ -1,4 +1,6 @@
 using Api.Project.Template.Api;
+using Api.Project.Template.Application.Messaging;
+using Api.Project.Template.Application.Messaging.Abstractions;
 using Api.Project.Template.Infrastructure.Data;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -26,6 +28,10 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>, IAsyn
         // call in Program.cs doesn't throw on missing configuration.
         builder.UseSetting("ConnectionStrings:ApiProjectTemplate", "Server=dummy");
 
+        // Prevent Program.cs from calling AddRabbitMqMessageBus/AddServiceBusMessageBus,
+        // which would register real broker singletons that attempt live connections.
+        builder.UseSetting("MessagingProvider", "None");
+
         // ConfigureTestServices runs after all app services are registered,
         // ensuring our overrides take precedence over Aspire's registrations.
         builder.ConfigureTestServices(services =>
@@ -48,6 +54,9 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>, IAsyn
             // Replace with a plain scoped DbContext backed by SQLite on the shared connection.
             services.AddDbContext<ApiProjectTemplateContext>(options =>
                 options.UseSqlite(_connection));
+
+            // Prevent real broker connection attempts — no RabbitMQ or Service Bus in tests.
+            services.AddSingleton<IMessagePublisher, NullMessagePublisher>();
         });
     }
 
@@ -55,5 +64,14 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>, IAsyn
     {
         await _connection.DisposeAsync();
         await base.DisposeAsync();
+    }
+
+    // Replaces the real broker publisher so integration tests don't attempt
+    // a live RabbitMQ or Service Bus connection. Registered last so it wins
+    // over any publisher registered by Program.cs (DI returns the last registration).
+    private sealed class NullMessagePublisher : IMessagePublisher
+    {
+        public Task PublishAsync<T>(T message, MessagePublishOptions? options = null, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
     }
 }

--- a/tests/Api.Project.Template.Tests.Unit/Features/Weather/Queries/GetWeatherForecastsQueryHandlerTests.cs
+++ b/tests/Api.Project.Template.Tests.Unit/Features/Weather/Queries/GetWeatherForecastsQueryHandlerTests.cs
@@ -5,6 +5,7 @@ using Api.Project.Template.Application.Features.Weather.Queries;
 using Api.Project.Template.Application.Features.Weather.Queries.Handlers;
 using Api.Project.Template.Domain.Entities;
 using FluentAssertions;
+using MediatR;
 using Moq;
 
 namespace Api.Project.Template.Tests.Unit.Features.Weather.Queries;
@@ -12,12 +13,14 @@ namespace Api.Project.Template.Tests.Unit.Features.Weather.Queries;
 public class GetWeatherForecastsQueryHandlerTests
 {
     private readonly Mock<IRepository> _repositoryMock;
+    private readonly Mock<IPublisher> _publisherMock;
     private readonly GetWeatherForecastsQueryHandler _handler;
 
     public GetWeatherForecastsQueryHandlerTests()
     {
         _repositoryMock = new Mock<IRepository>();
-        _handler = new GetWeatherForecastsQueryHandler(_repositoryMock.Object);
+        _publisherMock = new Mock<IPublisher>();
+        _handler = new GetWeatherForecastsQueryHandler(_repositoryMock.Object, _publisherMock.Object);
     }
 
     [Fact]

--- a/tests/Api.Project.Template.Tests.Unit/Infrastructure/Messaging/GenericMessageConsumerTests.cs
+++ b/tests/Api.Project.Template.Tests.Unit/Infrastructure/Messaging/GenericMessageConsumerTests.cs
@@ -1,0 +1,287 @@
+using Api.Project.Template.Application.Abstractions.Logging;
+using Api.Project.Template.Application.Messaging;
+using Api.Project.Template.Application.Messaging.Abstractions;
+using Api.Project.Template.Infrastructure.Messaging;
+using Api.Project.Template.Infrastructure.Messaging.Abstractions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Api.Project.Template.Tests.Unit.Infrastructure.Messaging;
+
+public class GenericMessageConsumerTests
+{
+    private readonly ServiceCollection _services = new();
+    private readonly Mock<IMessageBrokerAdapter> _mockAdapter = new();
+    private readonly IConfiguration _configuration = CreateTestConfiguration();
+    private readonly Mock<ILoggerAdapter<GenericMessageConsumer<TestMessage, IMessageProcessor<TestMessage>>>> _logger = new();
+    
+    [Fact]
+    public void Constructor_CreatesInstance()
+    {
+        // Arrange
+        var scopeFactory = _services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+
+        // Act
+        var consumer = new GenericMessageConsumer<TestMessage, IMessageProcessor<TestMessage>>(
+            _mockAdapter.Object,
+            _configuration,
+            scopeFactory,
+            _logger.Object);
+
+        // Assert
+        Assert.NotNull(consumer);
+    }
+
+    [Fact]
+    public void Constructor_ImplementsIMessageConsumer()
+    {
+        // Arrange
+        var scopeFactory = _services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+
+        // Act
+        var consumer = new GenericMessageConsumer<TestMessage, IMessageProcessor<TestMessage>>(
+            _mockAdapter.Object,
+            _configuration,
+            scopeFactory,
+            _logger.Object);
+
+        // Assert
+        Assert.IsType<IMessageConsumer>(consumer, exactMatch: false);
+    }
+
+    [Fact]
+    public async Task StartAsync_CallsAdapterConnectAsync()
+    {
+        // Arrange
+        var scopeFactory = _services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+        var consumer = new GenericMessageConsumer<TestMessage, IMessageProcessor<TestMessage>>(
+            _mockAdapter.Object,
+            _configuration,
+            scopeFactory,
+            _logger.Object);
+
+        _mockAdapter.Setup(a => a.ConnectAsync(
+            It.IsAny<MessageBrokerConfig>(),
+            It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _mockAdapter.Setup(a => a.SubscribeAsync(
+            It.IsAny<Func<TestMessage, MessageContext, Task<MessageProcessingResult>>>(),
+            It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await consumer.StartAsync(CancellationToken.None);
+
+        // Assert
+        _mockAdapter.Verify(a => a.ConnectAsync(
+            It.IsAny<MessageBrokerConfig>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task StartAsync_CallsAdapterSubscribeAsync()
+    {
+        // Arrange
+        var scopeFactory = _services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+        var consumer = new GenericMessageConsumer<TestMessage, IMessageProcessor<TestMessage>>(
+            _mockAdapter.Object,
+            _configuration,
+            scopeFactory,
+            _logger.Object);
+
+        _mockAdapter.Setup(a => a.ConnectAsync(
+            It.IsAny<MessageBrokerConfig>(),
+            It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _mockAdapter.Setup(a => a.SubscribeAsync(
+            It.IsAny<Func<TestMessage, MessageContext, Task<MessageProcessingResult>>>(),
+            It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await consumer.StartAsync(CancellationToken.None);
+
+        // Assert
+        _mockAdapter.Verify(a => a.SubscribeAsync(
+            It.IsAny<Func<TestMessage, MessageContext, Task<MessageProcessingResult>>>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task StopAsync_CallsAdapterDisconnectAsync()
+    {
+        // Arrange
+        var scopeFactory = _services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+        var consumer = new GenericMessageConsumer<TestMessage, IMessageProcessor<TestMessage>>(
+            _mockAdapter.Object,
+            _configuration,
+            scopeFactory,
+            _logger.Object);
+
+        _mockAdapter.Setup(a => a.DisconnectAsync())
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await consumer.StopAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        _mockAdapter.Verify(a => a.DisconnectAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_CallsAdapterDisposeAsync()
+    {
+        // Arrange
+        var scopeFactory = _services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+        var consumer = new GenericMessageConsumer<TestMessage, IMessageProcessor<TestMessage>>(
+            _mockAdapter.Object,
+            _configuration,
+            scopeFactory,
+            _logger.Object);
+
+        _mockAdapter.Setup(a => a.DisposeAsync())
+            .Returns(ValueTask.CompletedTask);
+
+        // Act
+        await consumer.DisposeAsync();
+
+        // Assert
+        _mockAdapter.Verify(a => a.DisposeAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task MessageHandler_ResolvesProcessorFromScope()
+    {
+        // Arrange
+        var mockProcessor = new Mock<IMessageProcessor<TestMessage>>();
+        mockProcessor.Setup(p => p.ProcessAsync(
+            It.IsAny<TestMessage>(),
+            It.IsAny<MessageContext>()))
+            .ReturnsAsync(MessageProcessingResult.Succeeded());
+
+        var processorInstance = mockProcessor.Object;
+        _services.AddScoped<IMessageProcessor<TestMessage>>(_ => processorInstance);
+        var scopeFactory = _services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+
+        Func<TestMessage, MessageContext, Task<MessageProcessingResult>>? capturedHandler = null;
+
+        _mockAdapter.Setup(a => a.ConnectAsync(
+            It.IsAny<MessageBrokerConfig>(),
+            It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _mockAdapter.Setup(a => a.SubscribeAsync(
+            It.IsAny<Func<TestMessage, MessageContext, Task<MessageProcessingResult>>>(),
+            It.IsAny<CancellationToken>()))
+            .Callback<Func<TestMessage, MessageContext, Task<MessageProcessingResult>>, CancellationToken>(
+                (handler, ct) => capturedHandler = handler)
+            .Returns(Task.CompletedTask);
+
+        var consumer = new GenericMessageConsumer<TestMessage, IMessageProcessor<TestMessage>>(
+            _mockAdapter.Object,
+            _configuration,
+            scopeFactory,
+            _logger.Object);
+
+        await consumer.StartAsync(CancellationToken.None);
+
+        Assert.NotNull(capturedHandler);
+
+        var testMessage = new TestMessage { Id = 1, Name = "Test" };
+        var testContext = new MessageContext
+        {
+            MessageId = "msg-1",
+            CorrelationId = "corr-1"
+        };
+
+        // Act
+        var result = await capturedHandler(testMessage, testContext);
+
+        // Assert
+        Assert.True(result.Success);
+        mockProcessor.Verify(p => p.ProcessAsync(
+            It.Is<TestMessage>(m => m.Id == 1 && m.Name == "Test"),
+            It.IsAny<MessageContext>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task MessageHandler_HandlesProcessorException()
+    {
+        // Arrange
+        var mockProcessor = new Mock<IMessageProcessor<TestMessage>>();
+        mockProcessor.Setup(p => p.ProcessAsync(
+            It.IsAny<TestMessage>(),
+            It.IsAny<MessageContext>()))
+            .ThrowsAsync(new InvalidOperationException("Test exception"));
+
+        var processorInstance = mockProcessor.Object;
+        _services.AddScoped<IMessageProcessor<TestMessage>>(_ => processorInstance);
+        var scopeFactory = _services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+
+        Func<TestMessage, MessageContext, Task<MessageProcessingResult>>? capturedHandler = null;
+
+        _mockAdapter.Setup(a => a.ConnectAsync(
+            It.IsAny<MessageBrokerConfig>(),
+            It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _mockAdapter.Setup(a => a.SubscribeAsync(
+            It.IsAny<Func<TestMessage, MessageContext, Task<MessageProcessingResult>>>(),
+            It.IsAny<CancellationToken>()))
+            .Callback<Func<TestMessage, MessageContext, Task<MessageProcessingResult>>, CancellationToken>(
+                (handler, ct) => capturedHandler = handler)
+            .Returns(Task.CompletedTask);
+
+        var consumer = new GenericMessageConsumer<TestMessage, IMessageProcessor<TestMessage>>(
+            _mockAdapter.Object,
+            _configuration,
+            scopeFactory,
+            _logger.Object);
+
+        await consumer.StartAsync(CancellationToken.None);
+
+        Assert.NotNull(capturedHandler);
+
+        var testMessage = new TestMessage { Id = 1, Name = "Test" };
+        var testContext = new MessageContext { MessageId = "msg-1" };
+
+        // Act
+        var result = await capturedHandler(testMessage, testContext);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.NotNull(result.Exception);
+        Assert.Equal("Test exception", result.ErrorReason);
+    }
+
+    // Helper methods
+
+    private static IConfiguration CreateTestConfiguration()
+    {
+        var configData = new Dictionary<string, string?>
+        {
+            ["ConnectionStrings:messaging"] = "amqp://localhost",
+            ["MessageBus:Consumer:Queue"] = "test-queue",
+            ["MessageBus:Consumer:Concurrency"] = "5",
+            ["MessageBus:Consumer:MaxRetries"] = "3",
+            ["MessageBus:Consumer:PrefetchCount"] = "10",
+            ["MessageBus:RabbitMq:Exchange"] = "test-exchange",
+            ["MessageBus:RabbitMq:RoutingKey"] = "test-key"
+        };
+
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(configData)
+            .Build();
+    }
+
+    // Test message type
+    public class TestMessage
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+}

--- a/tests/Api.Project.Template.Tests.Unit/Infrastructure/Messaging/MessageBrokerConfigTests.cs
+++ b/tests/Api.Project.Template.Tests.Unit/Infrastructure/Messaging/MessageBrokerConfigTests.cs
@@ -1,0 +1,156 @@
+
+using Api.Project.Template.Infrastructure.Messaging;
+
+namespace Api.Project.Template.Tests.Unit.Infrastructure.Messaging;
+
+public class MessageBrokerConfigTests
+{
+    [Fact]
+    public void Constructor_InitializesWithDefaultValues()
+    {
+        // Act
+        var config = new MessageBrokerConfig();
+
+        // Assert
+        Assert.Equal(string.Empty, config.ConnectionString);
+        Assert.Equal(string.Empty, config.Queue);
+        Assert.Equal(5, config.Concurrency);
+        Assert.Equal(3, config.MaxRetries);
+        Assert.Equal(10, config.PrefetchCount);
+        Assert.NotNull(config.ProviderSpecific);
+        Assert.Empty(config.ProviderSpecific);
+    }
+
+    [Fact]
+    public void ConnectionString_CanBeSet()
+    {
+        // Arrange
+        var config = new MessageBrokerConfig();
+        var connectionString = "amqp://localhost:5672";
+
+        // Act
+        config.ConnectionString = connectionString;
+
+        // Assert
+        Assert.Equal(connectionString, config.ConnectionString);
+    }
+
+    [Fact]
+    public void Queue_CanBeSet()
+    {
+        // Arrange
+        var config = new MessageBrokerConfig();
+        var queue = "my-queue";
+
+        // Act
+        config.Queue = queue;
+
+        // Assert
+        Assert.Equal(queue, config.Queue);
+    }
+
+    [Fact]
+    public void Concurrency_CanBeSet()
+    {
+        // Arrange
+        var config = new MessageBrokerConfig();
+
+        // Act
+        config.Concurrency = 10;
+
+        // Assert
+        Assert.Equal(10, config.Concurrency);
+    }
+
+    [Fact]
+    public void MaxRetries_CanBeSet()
+    {
+        // Arrange
+        var config = new MessageBrokerConfig();
+
+        // Act
+        config.MaxRetries = 5;
+
+        // Assert
+        Assert.Equal(5, config.MaxRetries);
+    }
+
+    [Fact]
+    public void PrefetchCount_CanBeSet()
+    {
+        // Arrange
+        var config = new MessageBrokerConfig();
+
+        // Act
+        config.PrefetchCount = 20;
+
+        // Assert
+        Assert.Equal(20, config.PrefetchCount);
+    }
+
+    [Fact]
+    public void ProviderSpecific_CanAddKeyValuePairs()
+    {
+        // Arrange
+        var config = new MessageBrokerConfig();
+
+        // Act
+        config.ProviderSpecific["Exchange"] = "my-exchange";
+        config.ProviderSpecific["RoutingKey"] = "my-routing-key";
+
+        // Assert
+        Assert.Equal(2, config.ProviderSpecific.Count);
+        Assert.Equal("my-exchange", config.ProviderSpecific["Exchange"]);
+        Assert.Equal("my-routing-key", config.ProviderSpecific["RoutingKey"]);
+    }
+
+    [Fact]
+    public void ProviderSpecific_CanBeReplacedWithNewDictionary()
+    {
+        // Arrange
+        var config = new MessageBrokerConfig();
+        var customSettings = new Dictionary<string, string>
+        {
+            ["SessionEnabled"] = "true",
+            ["PrefetchCount"] = "15"
+        };
+
+        // Act
+        config.ProviderSpecific = customSettings;
+
+        // Assert
+        Assert.Equal(2, config.ProviderSpecific.Count);
+        Assert.Equal("true", config.ProviderSpecific["SessionEnabled"]);
+        Assert.Equal("15", config.ProviderSpecific["PrefetchCount"]);
+    }
+
+    [Fact]
+    public void DefaultConcurrency_IsFive()
+    {
+        // Act
+        var config = new MessageBrokerConfig();
+
+        // Assert
+        Assert.Equal(5, config.Concurrency);
+    }
+
+    [Fact]
+    public void DefaultMaxRetries_IsThree()
+    {
+        // Act
+        var config = new MessageBrokerConfig();
+
+        // Assert
+        Assert.Equal(3, config.MaxRetries);
+    }
+
+    [Fact]
+    public void DefaultPrefetchCount_IsTen()
+    {
+        // Act
+        var config = new MessageBrokerConfig();
+
+        // Assert
+        Assert.Equal(10, config.PrefetchCount);
+    }
+}

--- a/tests/Api.Project.Template.Tests.Unit/Infrastructure/Messaging/MessageBusExtensionsTests.cs
+++ b/tests/Api.Project.Template.Tests.Unit/Infrastructure/Messaging/MessageBusExtensionsTests.cs
@@ -1,0 +1,379 @@
+using Api.Project.Template.Application.Abstractions.Logging;
+using Api.Project.Template.Application.Messaging.Abstractions;
+using Api.Project.Template.Infrastructure.Logging;
+using Api.Project.Template.Infrastructure.Messaging;
+using Api.Project.Template.Infrastructure.Messaging.Abstractions;
+using Api.Project.Template.Infrastructure.Messaging.RabbitMq;
+using Api.Project.Template.Infrastructure.Messaging.ServiceBus;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Api.Project.Template.Tests.Unit.Infrastructure.Messaging;
+
+public class MessageBusExtensionsTests
+{
+    [Theory]
+    [InlineData("RabbitMq", "RabbitMq")]
+    [InlineData("rabbitmq", "RabbitMq")]
+    [InlineData("RABBITMQ", "RabbitMq")]
+    [InlineData("ServiceBus", "ServiceBus")]
+    [InlineData("servicebus", "ServiceBus")]
+    [InlineData("SERVICEBUS", "ServiceBus")]
+    public void ResolveProvider_WithExplicitProvider_ReturnsNormalizedValue(string input, string expected)
+    {
+        // Arrange
+        var config = CreateEmptyConfiguration();
+
+        // Act
+        var result = MessageBusExtensions.ResolveProvider(input, config);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void ResolveProvider_WithInvalidProvider_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var config = CreateEmptyConfiguration();
+
+        // Act & Assert
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            MessageBusExtensions.ResolveProvider("Redis", config));
+
+        Assert.Contains("Invalid MessageBus:Routing:Provider value: 'Redis'", ex.Message);
+        Assert.Contains("Valid values: 'RabbitMq', 'ServiceBus', 'Auto'", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("Auto")]
+    [InlineData("auto")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void ResolveProvider_WithAutoOrEmpty_DetectsFromConnectionStrings(string? providerValue)
+    {
+        // Arrange - only RabbitMQ connection string
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:messaging"] = "amqp://guest:guest@localhost:5672/"
+            })
+            .Build();
+
+        // Act
+        var result = MessageBusExtensions.ResolveProvider(providerValue, config);
+
+        // Assert
+        Assert.Equal("RabbitMq", result);
+    }
+
+    [Fact]
+    public void DetectProvider_WithOnlyRabbitMqConnectionString_ReturnsRabbitMq()
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:messaging"] = "amqp://guest:guest@localhost:5672/"
+            })
+            .Build();
+
+        // Act
+        var result = MessageBusExtensions.DetectProvider(config);
+
+        // Assert
+        Assert.Equal("RabbitMq", result);
+    }
+
+    [Fact]
+    public void DetectProvider_WithOnlyServiceBusConnectionString_ReturnsServiceBus()
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:servicebus"] = "Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=test"
+            })
+            .Build();
+
+        // Act
+        var result = MessageBusExtensions.DetectProvider(config);
+
+        // Assert
+        Assert.Equal("ServiceBus", result);
+    }
+
+    [Fact]
+    public void DetectProvider_WithBothConnectionStrings_PrefersRabbitMq()
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:messaging"] = "amqp://guest:guest@localhost:5672/",
+                ["ConnectionStrings:servicebus"] = "Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=test"
+            })
+            .Build();
+
+        // Act
+        var result = MessageBusExtensions.DetectProvider(config);
+
+        // Assert
+        Assert.Equal("RabbitMq", result);
+    }
+
+    [Fact]
+    public void DetectProvider_WithNoConnectionStrings_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var config = CreateEmptyConfiguration();
+
+        // Act & Assert
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            MessageBusExtensions.DetectProvider(config));
+
+        Assert.Contains("No message broker connection string found", ex.Message);
+        Assert.Contains("ConnectionStrings:messaging", ex.Message);
+        Assert.Contains("ConnectionStrings:servicebus", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("MessageBus:RabbitMq:ConnectionString", "amqp://localhost")]
+    [InlineData("MessageBus:RabbitMq", "amqp://localhost")]
+    [InlineData("MessageBus__RabbitMq__ConnectionString", "amqp://localhost")]
+    [InlineData("MessageBus__RabbitMq", "amqp://localhost")]
+    [InlineData("ConnectionStrings:RabbitMq", "amqp://localhost")]
+    [InlineData("ConnectionStrings:messaging", "amqp://localhost")]
+    public void HasRabbitMqConnectionString_WithValidConnectionString_ReturnsTrue(string key, string value)
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [key] = value
+            })
+            .Build();
+
+        // Act
+        var result = MessageBusExtensions.HasRabbitMqConnectionString(config);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void HasRabbitMqConnectionString_WithNoConnectionString_ReturnsFalse()
+    {
+        // Arrange
+        var config = CreateEmptyConfiguration();
+
+        // Act
+        var result = MessageBusExtensions.HasRabbitMqConnectionString(config);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void HasRabbitMqConnectionString_WithEmptyConnectionString_ReturnsFalse()
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:messaging"] = ""
+            })
+            .Build();
+
+        // Act
+        var result = MessageBusExtensions.HasRabbitMqConnectionString(config);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Theory]
+    [InlineData("ConnectionStrings:servicebus", "Endpoint=sb://localhost")]
+    public void HasServiceBusConnectionString_WithValidConnectionString_ReturnsTrue(string key, string value)
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [key] = value
+            })
+            .Build();
+
+        // Act
+        var result = MessageBusExtensions.HasServiceBusConnectionString(config);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void HasServiceBusConnectionString_WithNoConnectionString_ReturnsFalse()
+    {
+        // Arrange
+        var config = CreateEmptyConfiguration();
+
+        // Act
+        var result = MessageBusExtensions.HasServiceBusConnectionString(config);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void HasServiceBusConnectionString_WithEmptyConnectionString_ReturnsFalse()
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:servicebus"] = ""
+            })
+            .Build();
+
+        // Act
+        var result = MessageBusExtensions.HasServiceBusConnectionString(config);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void AddMessageBus_WithRabbitMqProvider_RegistersRabbitMqBrokerAdapter()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(typeof(ILoggerAdapter<>), typeof(LoggerAdapter<>));
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:messaging"] = "amqp://guest:guest@localhost:5672/",
+                ["MessageBus:Routing:Provider"] = "RabbitMq"
+            })
+            .Build();
+
+        // Act
+        services.AddMessageBus(config);
+        var serviceProvider = services.BuildServiceProvider();
+
+        // Assert
+        var adapter = serviceProvider.GetService<IMessageBrokerAdapter>();
+        Assert.NotNull(adapter);
+        Assert.IsType<RabbitMqBrokerAdapter>(adapter);
+    }
+
+    [Fact]
+    public void AddMessageBus_WithServiceBusProvider_RegistersServiceBusBrokerAdapter()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(typeof(ILoggerAdapter<>), typeof(LoggerAdapter<>));
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:servicebus"] = "Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=test",
+                ["MessageBus:Routing:Provider"] = "ServiceBus"
+            })
+            .Build();
+
+        // Act
+        services.AddMessageBus(config);
+        var serviceProvider = services.BuildServiceProvider();
+
+        // Assert
+        var adapter = serviceProvider.GetService<IMessageBrokerAdapter>();
+        Assert.NotNull(adapter);
+        Assert.IsType<ServiceBusBrokerAdapter>(adapter);
+    }
+
+    [Fact]
+    public void AddMessageBus_WithAutoProvider_RabbitMqConnectionString_RegistersRabbitMqBrokerAdapter()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(typeof(ILoggerAdapter<>), typeof(LoggerAdapter<>));
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:messaging"] = "amqp://guest:guest@localhost:5672/",
+                ["MessageBus:Routing:Provider"] = "Auto"
+            })
+            .Build();
+
+        // Act
+        services.AddMessageBus(config);
+        var serviceProvider = services.BuildServiceProvider();
+
+        // Assert
+        var adapter = serviceProvider.GetService<IMessageBrokerAdapter>();
+        Assert.NotNull(adapter);
+        Assert.IsType<RabbitMqBrokerAdapter>(adapter);
+    }
+
+    [Fact]
+    public void AddMessageBus_RegistersBothPublisherAndConsumerAdapter()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(typeof(ILoggerAdapter<>), typeof(LoggerAdapter<>));
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:messaging"] = "amqp://guest:guest@localhost:5672/",
+                ["MessageBus:Routing:Provider"] = "RabbitMq"
+            })
+            .Build();
+
+        services.AddSingleton<IConfiguration>(config);
+
+        // Act
+        services.AddMessageBus(config);
+        var serviceProvider = services.BuildServiceProvider();
+
+        // Assert
+        var publisher = serviceProvider.GetService<IMessagePublisher>();
+        var adapter = serviceProvider.GetService<IMessageBrokerAdapter>();
+
+        Assert.NotNull(publisher);
+        Assert.NotNull(adapter);
+        Assert.IsType<RoutingMessagePublisher>(publisher);
+        Assert.IsType<RabbitMqBrokerAdapter>(adapter);
+    }
+
+    [Fact]
+    public void AddMessageBus_WithInvalidProvider_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:messaging"] = "amqp://guest:guest@localhost:5672/",
+                ["MessageBus:Routing:Provider"] = "Kafka"
+            })
+            .Build();
+
+        // Act & Assert
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            services.AddMessageBus(config));
+
+        Assert.Contains("Invalid MessageBus:Routing:Provider value: 'Kafka'", ex.Message);
+        Assert.Contains("Valid values: 'RabbitMq', 'ServiceBus', 'Auto'", ex.Message);
+    }
+
+    private static IConfiguration CreateEmptyConfiguration()
+    {
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>())
+            .Build();
+    }
+}

--- a/tests/Api.Project.Template.Tests.Unit/Infrastructure/Messaging/MessageContextTests.cs
+++ b/tests/Api.Project.Template.Tests.Unit/Infrastructure/Messaging/MessageContextTests.cs
@@ -1,0 +1,168 @@
+
+using Api.Project.Template.Application.Messaging;
+
+namespace Api.Project.Template.Tests.Unit.Infrastructure.Messaging;
+
+public class MessageContextTests
+{
+    [Fact]
+    public void Constructor_WithInitializers_SetsPropertiesCorrectly()
+    {
+        // Arrange
+        var messageId = "msg-123";
+        var correlationId = "corr-456";
+        var deliveryCount = 2;
+        var headers = new Dictionary<string, object>
+        {
+            ["ContentType"] = "application/json",
+            ["Priority"] = 5
+        };
+        var cancellationToken = new CancellationToken();
+
+        // Act
+        var context = new MessageContext
+        {
+            MessageId = messageId,
+            CorrelationId = correlationId,
+            DeliveryCount = deliveryCount,
+            Headers = headers,
+            CancellationToken = cancellationToken
+        };
+
+        // Assert
+        Assert.Equal(messageId, context.MessageId);
+        Assert.Equal(correlationId, context.CorrelationId);
+        Assert.Equal(deliveryCount, context.DeliveryCount);
+        Assert.Same(headers, context.Headers);
+        Assert.Equal(cancellationToken, context.CancellationToken);
+    }
+
+    [Fact]
+    public void MessageId_DefaultsToEmptyString()
+    {
+        // Act
+        var context = new MessageContext();
+
+        // Assert
+        Assert.Equal(string.Empty, context.MessageId);
+    }
+
+    [Fact]
+    public void CorrelationId_DefaultsToEmptyString()
+    {
+        // Act
+        var context = new MessageContext();
+
+        // Assert
+        Assert.Equal(string.Empty, context.CorrelationId);
+    }
+
+    [Fact]
+    public void DeliveryCount_DefaultsToZero()
+    {
+        // Act
+        var context = new MessageContext();
+
+        // Assert
+        Assert.Equal(0, context.DeliveryCount);
+    }
+
+    [Fact]
+    public void Headers_DefaultsToEmptyDictionary()
+    {
+        // Act
+        var context = new MessageContext();
+
+        // Assert
+        Assert.NotNull(context.Headers);
+        Assert.Empty(context.Headers);
+    }
+
+    [Fact]
+    public void CancellationToken_DefaultsToNone()
+    {
+        // Act
+        var context = new MessageContext();
+
+        // Assert
+        Assert.Equal(CancellationToken.None, context.CancellationToken);
+    }
+
+    [Fact]
+    public void Headers_IsReadOnly_CannotBeModifiedAfterCreation()
+    {
+        // Arrange
+        var headers = new Dictionary<string, object>
+        {
+            ["Key1"] = "Value1"
+        };
+        var context = new MessageContext
+        {
+            Headers = headers
+        };
+
+        // Act & Assert
+        // Headers property returns IReadOnlyDictionary, so we can't modify it
+        // This test verifies the type is correct
+        Assert.IsAssignableFrom<IReadOnlyDictionary<string, object>>(context.Headers);
+    }
+
+    [Fact]
+    public void Properties_UseInitAccessor_CannotBeSetAfterConstruction()
+    {
+        // Arrange
+        var context = new MessageContext
+        {
+            MessageId = "initial-id",
+            CorrelationId = "initial-corr"
+        };
+
+        // Assert
+        // If this compiles without error, it means we're using init accessors correctly
+        // Attempting to reassign would cause a compile error
+        Assert.Equal("initial-id", context.MessageId);
+        Assert.Equal("initial-corr", context.CorrelationId);
+    }
+
+    [Fact]
+    public void ProviderContext_CanBeSetInternally()
+    {
+        // Arrange & Act
+        var context = new MessageContext();
+
+        // Assert
+        // ProviderContext is internal, so we can't test it directly from this assembly
+        // This test just verifies the class can be instantiated
+        Assert.NotNull(context);
+    }
+
+    [Fact]
+    public void FullyPopulatedContext_HasAllProperties()
+    {
+        // Arrange
+        var headers = new Dictionary<string, object>
+        {
+            ["MessageType"] = "TestMessage",
+            ["Timestamp"] = DateTimeOffset.UtcNow
+        };
+        var cts = new CancellationTokenSource();
+
+        // Act
+        var context = new MessageContext
+        {
+            MessageId = "msg-abc-123",
+            CorrelationId = "corr-xyz-789",
+            DeliveryCount = 3,
+            Headers = headers,
+            CancellationToken = cts.Token
+        };
+
+        // Assert
+        Assert.Equal("msg-abc-123", context.MessageId);
+        Assert.Equal("corr-xyz-789", context.CorrelationId);
+        Assert.Equal(3, context.DeliveryCount);
+        Assert.Equal(2, context.Headers.Count);
+        Assert.Equal("TestMessage", context.Headers["MessageType"]);
+        Assert.False(context.CancellationToken.IsCancellationRequested);
+    }
+}

--- a/tests/Api.Project.Template.Tests.Unit/Infrastructure/Messaging/MessageProcessingResultTests.cs
+++ b/tests/Api.Project.Template.Tests.Unit/Infrastructure/Messaging/MessageProcessingResultTests.cs
@@ -1,0 +1,96 @@
+
+using Api.Project.Template.Application.Messaging;
+
+namespace Api.Project.Template.Tests.Unit.Infrastructure.Messaging;
+
+public class MessageProcessingResultTests
+{
+    [Fact]
+    public void Succeeded_CreatesSuccessResult()
+    {
+        // Act
+        var result = MessageProcessingResult.Succeeded();
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.False(result.Requeue);
+        Assert.Null(result.ErrorReason);
+        Assert.Null(result.Exception);
+    }
+
+    [Fact]
+    public void Failed_WithReasonOnly_CreatesFailureResult()
+    {
+        // Arrange
+        var reason = "Processing failed due to validation error";
+
+        // Act
+        var result = MessageProcessingResult.Failed(reason);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.False(result.Requeue);
+        Assert.Equal(reason, result.ErrorReason);
+        Assert.Null(result.Exception);
+    }
+
+    [Fact]
+    public void Failed_WithReasonAndRequeue_CreatesFailureResultWithRequeue()
+    {
+        // Arrange
+        var reason = "Temporary database connection failure";
+
+        // Act
+        var result = MessageProcessingResult.Failed(reason, requeue: true);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.True(result.Requeue);
+        Assert.Equal(reason, result.ErrorReason);
+        Assert.Null(result.Exception);
+    }
+
+    [Fact]
+    public void FailedWithException_WithExceptionOnly_CreatesFailureWithException()
+    {
+        // Arrange
+        var exception = new InvalidOperationException("Operation failed");
+
+        // Act
+        var result = MessageProcessingResult.FailedWithException(exception);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.False(result.Requeue);
+        Assert.Equal("Operation failed", result.ErrorReason);
+        Assert.Same(exception, result.Exception);
+    }
+
+    [Fact]
+    public void FailedWithException_WithExceptionAndRequeue_CreatesFailureWithExceptionAndRequeue()
+    {
+        // Arrange
+        var exception = new TimeoutException("Request timed out");
+
+        // Act
+        var result = MessageProcessingResult.FailedWithException(exception, requeue: true);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.True(result.Requeue);
+        Assert.Equal("Request timed out", result.ErrorReason);
+        Assert.Same(exception, result.Exception);
+    }
+
+    [Fact]
+    public void Properties_AreInitOnly_CannotBeModifiedAfterCreation()
+    {
+        // Arrange
+        var result = MessageProcessingResult.Succeeded();
+
+        // Assert - This test verifies that properties use 'init' accessor
+        // If this compiles, it means we can create the object
+        // If we tried to set a property after creation, it would be a compile error
+        Assert.NotNull(result);
+    }
+}

--- a/tests/Api.Project.Template.Tests.Unit/Infrastructure/Messaging/MessageRoutingConfigTests.cs
+++ b/tests/Api.Project.Template.Tests.Unit/Infrastructure/Messaging/MessageRoutingConfigTests.cs
@@ -1,0 +1,143 @@
+using Api.Project.Template.Infrastructure.Messaging;
+using Microsoft.Extensions.Configuration;
+
+namespace Api.Project.Template.Tests.Unit.Infrastructure.Messaging;
+
+public class MessageRoutingConfigTests
+{
+    [Fact]
+    public void Bind_WithFullConfiguration_BindsAllProperties()
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["MessageBus:Routing:Provider"] = "RabbitMq",
+                ["MessageBus:Routing:DefaultDestination"] = "apiprojecttemplate.events",
+                ["MessageBus:Routing:DefaultRoutingKey"] = "default",
+                ["MessageBus:Routing:Routes:WeatherRequested:Destination"] = "sample-requests",
+                ["MessageBus:Routing:Routes:WeatherRequested:RoutingKey"] = "WeatherRequested",
+                ["MessageBus:Routing:Routes:WeatherRequested:Subject"] = "sample-subject"
+            })
+            .Build();
+
+        // Act
+        var routingConfig = config.GetSection("MessageBus:Routing").Get<MessageRoutingConfig>();
+
+        // Assert
+        Assert.NotNull(routingConfig);
+        Assert.Equal("RabbitMq", routingConfig.Provider);
+        Assert.Equal("apiprojecttemplate.events", routingConfig.DefaultDestination);
+        Assert.Equal("default", routingConfig.DefaultRoutingKey);
+        Assert.Single(routingConfig.Routes);
+        Assert.True(routingConfig.Routes.ContainsKey("WeatherRequested"));
+
+        var weatherRoute = routingConfig.Routes["WeatherRequested"];
+        Assert.Equal("sample-requests", weatherRoute.Destination);
+        Assert.Equal("WeatherRequested", weatherRoute.RoutingKey);
+        Assert.Equal("sample-subject", weatherRoute.Subject);
+    }
+
+    [Fact]
+    public void Bind_WithEmptyConfiguration_ProducesValidDefaults()
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>())
+            .Build();
+
+        // Act
+        var routingConfig = config.GetSection("MessageBus:Routing").Get<MessageRoutingConfig>()
+            ?? new MessageRoutingConfig();
+
+        // Assert
+        Assert.NotNull(routingConfig);
+        Assert.Equal("Auto", routingConfig.Provider);
+        Assert.Null(routingConfig.DefaultDestination);
+        Assert.Null(routingConfig.DefaultRoutingKey);
+        Assert.Empty(routingConfig.Routes);
+    }
+
+    [Fact]
+    public void Bind_WithMetadata_BindsMetadataDictionary()
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["MessageBus:Routing:Routes:WeatherRequested:Destination"] = "sample-requests",
+                ["MessageBus:Routing:Routes:WeatherRequested:Metadata:priority"] = "high",
+                ["MessageBus:Routing:Routes:WeatherRequested:Metadata:retryCount"] = "3"
+            })
+            .Build();
+
+        // Act
+        var routingConfig = config.GetSection("MessageBus:Routing").Get<MessageRoutingConfig>();
+
+        // Assert
+        Assert.NotNull(routingConfig);
+        Assert.Single(routingConfig.Routes);
+
+        var weatherRoute = routingConfig.Routes["WeatherRequested"];
+        Assert.NotNull(weatherRoute.Metadata);
+        Assert.Equal(2, weatherRoute.Metadata.Count);
+        Assert.Equal("high", weatherRoute.Metadata["priority"]);
+        Assert.Equal("3", weatherRoute.Metadata["retryCount"]);
+    }
+
+    [Fact]
+    public void Bind_WithProviderOnly_UsesDefaultsForOtherProperties()
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["MessageBus:Routing:Provider"] = "ServiceBus"
+            })
+            .Build();
+
+        // Act
+        var routingConfig = config.GetSection("MessageBus:Routing").Get<MessageRoutingConfig>();
+
+        // Assert
+        Assert.NotNull(routingConfig);
+        Assert.Equal("ServiceBus", routingConfig.Provider);
+        Assert.Null(routingConfig.DefaultDestination);
+        Assert.Null(routingConfig.DefaultRoutingKey);
+        Assert.Empty(routingConfig.Routes);
+    }
+
+    [Fact]
+    public void MessageRoute_DefaultValues_AreNull()
+    {
+        // Arrange & Act
+        var route = new MessageRoute();
+
+        // Assert
+        Assert.Null(route.Destination);
+        Assert.Null(route.RoutingKey);
+        Assert.Null(route.Subject);
+        Assert.Null(route.Metadata);
+    }
+
+    [Fact]
+    public void MessageRoutingConfig_DefaultProvider_IsAuto()
+    {
+        // Arrange & Act
+        var config = new MessageRoutingConfig();
+
+        // Assert
+        Assert.Equal("Auto", config.Provider);
+    }
+
+    [Fact]
+    public void MessageRoutingConfig_DefaultRoutes_IsEmptyDictionary()
+    {
+        // Arrange & Act
+        var config = new MessageRoutingConfig();
+
+        // Assert
+        Assert.NotNull(config.Routes);
+        Assert.Empty(config.Routes);
+    }
+}

--- a/tests/Api.Project.Template.Tests.Unit/Infrastructure/Messaging/RabbitMq/RabbitMqBrokerAdapterTests.cs
+++ b/tests/Api.Project.Template.Tests.Unit/Infrastructure/Messaging/RabbitMq/RabbitMqBrokerAdapterTests.cs
@@ -1,0 +1,132 @@
+using Api.Project.Template.Application.Abstractions.Logging;
+using Api.Project.Template.Application.Messaging;
+using Api.Project.Template.Infrastructure.Messaging;
+using Api.Project.Template.Infrastructure.Messaging.Abstractions;
+using Api.Project.Template.Infrastructure.Messaging.RabbitMq;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Api.Project.Template.Tests.Unit.Infrastructure.Messaging.RabbitMq;
+
+public class RabbitMqBrokerAdapterTests
+{
+    private readonly Mock<ILoggerAdapter<RabbitMqBrokerAdapter>> _logger = new();
+
+    [Fact]
+    public void Constructor_CreatesInstance()
+    {
+        // Act
+        var adapter = new RabbitMqBrokerAdapter(_logger.Object);
+
+        // Assert
+        Assert.NotNull(adapter);
+    }
+
+    [Fact]
+    public void Constructor_ImplementsIMessageBrokerAdapter()
+    {
+        // Act
+        var adapter = new RabbitMqBrokerAdapter(_logger.Object);
+
+        // Assert
+        Assert.IsAssignableFrom<IMessageBrokerAdapter>(adapter);
+    }
+
+    [Fact]
+    public void Constructor_ImplementsIAsyncDisposable()
+    {
+        // Act
+        var adapter = new RabbitMqBrokerAdapter(_logger.Object);
+
+        // Assert
+        Assert.IsType<IAsyncDisposable>(adapter, exactMatch: false);
+    }
+
+    [Fact]
+    public async Task ConnectAsync_RequiresConnectionString()
+    {
+        // Arrange
+        var adapter = new RabbitMqBrokerAdapter(_logger.Object);
+
+        var config = new MessageBrokerConfig
+        {
+            ConnectionString = "", // Empty connection string
+            Queue = "test-queue"
+        };
+
+        // Act & Assert
+        // This will fail to connect, but we're testing that it attempts to parse
+        // In a real scenario, we'd need a mock or actual RabbitMQ
+        await Assert.ThrowsAnyAsync<Exception>(async () =>
+        {
+            await adapter.ConnectAsync(config, CancellationToken.None);
+        });
+    }
+
+    [Fact]
+    public async Task DisposeAsync_CanBeCalledWithoutConnect()
+    {
+        // Arrange
+        var adapter = new RabbitMqBrokerAdapter(_logger.Object);
+
+        // Act & Assert - should not throw
+        await adapter.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task DisconnectAsync_CanBeCalledWithoutConnect()
+    {
+        // Arrange
+        var adapter = new RabbitMqBrokerAdapter(_logger.Object);
+
+        // Act & Assert - should not throw
+        await adapter.DisconnectAsync();
+    }
+
+    [Fact]
+    public async Task SubscribeAsync_WithoutConnect_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var adapter = new RabbitMqBrokerAdapter(_logger.Object);
+
+        Task<MessageProcessingResult> Handler(TestMessage msg, MessageContext ctx)
+        {
+            return Task.FromResult(MessageProcessingResult.Succeeded());
+        }
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await adapter.SubscribeAsync<TestMessage>(Handler, CancellationToken.None);
+        });
+    }
+
+    [Fact]
+    public void MessageBrokerConfig_SupportsProviderSpecificSettings()
+    {
+        // Arrange
+        var config = new MessageBrokerConfig
+        {
+            ConnectionString = "amqp://localhost",
+            Queue = "test-queue",
+            ProviderSpecific = new Dictionary<string, string>
+            {
+                ["Exchange"] = "custom-exchange",
+                ["RoutingKey"] = "custom-key",
+                ["ExchangeType"] = "fanout"
+            }
+        };
+
+        // Assert
+        Assert.Equal("custom-exchange", config.ProviderSpecific["Exchange"]);
+        Assert.Equal("custom-key", config.ProviderSpecific["RoutingKey"]);
+        Assert.Equal("fanout", config.ProviderSpecific["ExchangeType"]);
+    }
+
+    // Test message type
+    private class TestMessage
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+}

--- a/tests/Api.Project.Template.Tests.Unit/Infrastructure/Messaging/RoutingMessagePublisherTests.cs
+++ b/tests/Api.Project.Template.Tests.Unit/Infrastructure/Messaging/RoutingMessagePublisherTests.cs
@@ -1,0 +1,414 @@
+using Api.Project.Template.Application.Abstractions.Logging;
+using Api.Project.Template.Application.Messaging;
+using Api.Project.Template.Application.Messaging.Abstractions;
+using Api.Project.Template.Infrastructure.Messaging;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Api.Project.Template.Tests.Unit.Infrastructure.Messaging;
+
+public class RoutingMessagePublisherTests
+{
+    private readonly Mock<IMessagePublisher> _mockInnerPublisher;
+    private readonly Mock<ILoggerAdapter<RoutingMessagePublisher>> _logger;
+
+    public RoutingMessagePublisherTests()
+    {
+        _mockInnerPublisher = new Mock<IMessagePublisher>();
+        _logger = new Mock<ILoggerAdapter<RoutingMessagePublisher>>();
+    }
+
+    [Fact]
+    public async Task PublishAsync_WithConfiguredRoute_ResolvesDestinationFromConfig()
+    {
+        // Arrange
+        var routingConfig = new MessageRoutingConfig
+        {
+            Routes = new Dictionary<string, MessageRoute>
+            {
+                ["TestMessage"] = new MessageRoute
+                {
+                    Destination = "test-queue",
+                    RoutingKey = "TestMessage"
+                }
+            }
+        };
+
+        var publisher = CreatePublisher(routingConfig);
+        var message = new TestMessage { Id = Guid.NewGuid() };
+
+        // Act
+        await publisher.PublishAsync(message, cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        _mockInnerPublisher.Verify(p => p.PublishAsync(
+            message,
+            It.Is<MessagePublishOptions>(o =>
+                o.Destination == "test-queue" &&
+                o.Subject == "TestMessage"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task PublishAsync_WithUnknownMessageType_FallsBackToDefaults()
+    {
+        // Arrange
+        var routingConfig = new MessageRoutingConfig
+        {
+            DefaultDestination = "default-exchange",
+            DefaultRoutingKey = "default-key",
+            Routes = new Dictionary<string, MessageRoute>() // Empty - no routes configured
+        };
+
+        var publisher = CreatePublisher(routingConfig);
+        var message = new UnknownMessage { Data = "test" };
+
+        // Act
+        await publisher.PublishAsync(message, cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        _mockInnerPublisher.Verify(p => p.PublishAsync(
+            message,
+            It.Is<MessagePublishOptions>(o =>
+                o.Destination == "default-exchange" &&
+                o.Subject == "default-key"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task PublishAsync_WithNoDefaultRoutingKey_UsesMessageTypeName()
+    {
+        // Arrange
+        var routingConfig = new MessageRoutingConfig
+        {
+            DefaultDestination = "default-exchange",
+            DefaultRoutingKey = null, // No default routing key
+            Routes = new Dictionary<string, MessageRoute>()
+        };
+
+        var publisher = CreatePublisher(routingConfig);
+        var message = new UnknownMessage { Data = "test" };
+
+        // Act
+        await publisher.PublishAsync(message, cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        _mockInnerPublisher.Verify(p => p.PublishAsync(
+            message,
+            It.Is<MessagePublishOptions>(o =>
+                o.Destination == "default-exchange" &&
+                o.Subject == "UnknownMessage"), // Uses type name as routing key
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task PublishAsync_WithExplicitDestination_BypassesRoutingConfig()
+    {
+        // Arrange
+        var routingConfig = new MessageRoutingConfig
+        {
+            Routes = new Dictionary<string, MessageRoute>
+            {
+                ["TestMessage"] = new MessageRoute
+                {
+                    Destination = "config-queue",
+                    RoutingKey = "ConfigKey"
+                }
+            }
+        };
+
+        var publisher = CreatePublisher(routingConfig);
+        var message = new TestMessage { Id = Guid.NewGuid() };
+        var explicitOptions = new MessagePublishOptions
+        {
+            Destination = "explicit-queue",
+            Subject = "ExplicitKey"
+        };
+
+        // Act
+        await publisher.PublishAsync(message, explicitOptions, TestContext.Current.CancellationToken);
+
+        // Assert
+        _mockInnerPublisher.Verify(p => p.PublishAsync(
+            message,
+            It.Is<MessagePublishOptions>(o =>
+                o.Destination == "explicit-queue" &&
+                o.Subject == "ExplicitKey"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task PublishAsync_WithSameMessageTypeMultipleTimes_CachesRoutingResolution()
+    {
+        // Arrange
+        var routingConfig = new MessageRoutingConfig
+        {
+            Routes = new Dictionary<string, MessageRoute>
+            {
+                ["TestMessage"] = new MessageRoute
+                {
+                    Destination = "test-queue",
+                    RoutingKey = "TestMessage"
+                }
+            }
+        };
+
+        var publisher = CreatePublisher(routingConfig);
+        var message1 = new TestMessage { Id = Guid.NewGuid() };
+        var message2 = new TestMessage { Id = Guid.NewGuid() };
+        var message3 = new TestMessage { Id = Guid.NewGuid() };
+
+        // Act
+        await publisher.PublishAsync(message1, cancellationToken: TestContext.Current.CancellationToken);
+        await publisher.PublishAsync(message2, cancellationToken: TestContext.Current.CancellationToken);
+        await publisher.PublishAsync(message3, cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert - inner publisher called 3 times with same routing
+        _mockInnerPublisher.Verify(p => p.PublishAsync(
+            It.IsAny<TestMessage>(),
+            It.Is<MessagePublishOptions>(o =>
+                o.Destination == "test-queue" &&
+                o.Subject == "TestMessage"),
+            It.IsAny<CancellationToken>()), Times.Exactly(3));
+    }
+
+    [Fact]
+    public async Task PublishAsync_WithRouteSubjectOnly_UsesSubjectAsRoutingKey()
+    {
+        // Arrange
+        var routingConfig = new MessageRoutingConfig
+        {
+            Routes = new Dictionary<string, MessageRoute>
+            {
+                ["TestMessage"] = new MessageRoute
+                {
+                    Destination = "test-queue",
+                    Subject = "SubjectValue" // Subject, not RoutingKey
+                }
+            }
+        };
+
+        var publisher = CreatePublisher(routingConfig);
+        var message = new TestMessage { Id = Guid.NewGuid() };
+
+        // Act
+        await publisher.PublishAsync(message, cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        _mockInnerPublisher.Verify(p => p.PublishAsync(
+            message,
+            It.Is<MessagePublishOptions>(o =>
+                o.Destination == "test-queue" &&
+                o.Subject == "SubjectValue"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task PublishAsync_WithRouteRoutingKeyPreferred_UsesRoutingKeyOverSubject()
+    {
+        // Arrange
+        var routingConfig = new MessageRoutingConfig
+        {
+            Routes = new Dictionary<string, MessageRoute>
+            {
+                ["TestMessage"] = new MessageRoute
+                {
+                    Destination = "test-queue",
+                    RoutingKey = "RoutingKeyValue",
+                    Subject = "SubjectValue"
+                }
+            }
+        };
+
+        var publisher = CreatePublisher(routingConfig);
+        var message = new TestMessage { Id = Guid.NewGuid() };
+
+        // Act
+        await publisher.PublishAsync(message, cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert - RoutingKey takes precedence over Subject
+        _mockInnerPublisher.Verify(p => p.PublishAsync(
+            message,
+            It.Is<MessagePublishOptions>(o =>
+                o.Destination == "test-queue" &&
+                o.Subject == "RoutingKeyValue"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task PublishAsync_WithNullMessage_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var routingConfig = new MessageRoutingConfig();
+        var publisher = CreatePublisher(routingConfig);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            publisher.PublishAsync<TestMessage>(null!, cancellationToken: TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task PublishAsync_WithRouteMetadata_MergesWithUserMetadata()
+    {
+        // Arrange
+        var routingConfig = new MessageRoutingConfig
+        {
+            Routes = new Dictionary<string, MessageRoute>
+            {
+                ["TestMessage"] = new MessageRoute
+                {
+                    Destination = "test-queue",
+                    RoutingKey = "TestMessage",
+                    Metadata = new Dictionary<string, string>
+                    {
+                        ["route-key"] = "route-value"
+                    }
+                }
+            }
+        };
+
+        var publisher = CreatePublisher(routingConfig);
+        var message = new TestMessage { Id = Guid.NewGuid() };
+
+        // Act
+        await publisher.PublishAsync(message, cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        _mockInnerPublisher.Verify(p => p.PublishAsync(
+            message,
+            It.Is<MessagePublishOptions>(o =>
+                o.Metadata != null &&
+                o.Metadata.ContainsKey("route-key") &&
+                (string)o.Metadata["route-key"] == "route-value"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task PublishAsync_WithRouteDestinationNull_FallsBackToDefaultDestination()
+    {
+        // Arrange
+        var routingConfig = new MessageRoutingConfig
+        {
+            DefaultDestination = "default-exchange",
+            Routes = new Dictionary<string, MessageRoute>
+            {
+                ["TestMessage"] = new MessageRoute
+                {
+                    Destination = null, // No destination specified
+                    RoutingKey = "TestMessage"
+                }
+            }
+        };
+
+        var publisher = CreatePublisher(routingConfig);
+        var message = new TestMessage { Id = Guid.NewGuid() };
+
+        // Act
+        await publisher.PublishAsync(message, cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        _mockInnerPublisher.Verify(p => p.PublishAsync(
+            message,
+            It.Is<MessagePublishOptions>(o =>
+                o.Destination == "default-exchange" &&
+                o.Subject == "TestMessage"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_WithAsyncDisposableInnerPublisher_DisposesInner()
+    {
+        // Arrange
+        var mockAsyncDisposable = new Mock<IMessagePublisher>();
+        mockAsyncDisposable.As<IAsyncDisposable>();
+
+        var routingConfig = new MessageRoutingConfig();
+        var publisher = new RoutingMessagePublisher(
+            mockAsyncDisposable.Object,
+            Options.Create(routingConfig),
+            _logger.Object);
+
+        // Act
+        await publisher.DisposeAsync();
+
+        // Assert
+        mockAsyncDisposable.As<IAsyncDisposable>().Verify(d => d.DisposeAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_WithDisposableInnerPublisher_DisposesInner()
+    {
+        // Arrange
+        var mockDisposable = new Mock<IMessagePublisher>();
+        mockDisposable.As<IDisposable>();
+
+        var routingConfig = new MessageRoutingConfig();
+        var publisher = new RoutingMessagePublisher(
+            mockDisposable.Object,
+            Options.Create(routingConfig),
+            _logger.Object);
+
+        // Act
+        await publisher.DisposeAsync();
+
+        // Assert
+        mockDisposable.As<IDisposable>().Verify(d => d.Dispose(), Times.Once);
+    }
+
+    [Fact]
+    public void Constructor_WithNullInnerPublisher_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var routingConfig = new MessageRoutingConfig();
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new RoutingMessagePublisher(
+            null!,
+            Options.Create(routingConfig),
+            _logger.Object));
+    }
+
+    [Fact]
+    public void Constructor_WithNullRoutingConfig_ThrowsArgumentNullException()
+    {
+        // Arrange & Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new RoutingMessagePublisher(
+            _mockInnerPublisher.Object,
+            null!,
+            _logger.Object));
+    }
+
+    [Fact]
+    public void Constructor_WithNullLogger_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var routingConfig = new MessageRoutingConfig();
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new RoutingMessagePublisher(
+            _mockInnerPublisher.Object,
+            Options.Create(routingConfig),
+            null!));
+    }
+
+    private RoutingMessagePublisher CreatePublisher(MessageRoutingConfig config)
+    {
+        return new RoutingMessagePublisher(
+            _mockInnerPublisher.Object,
+            Options.Create(config),
+            (ILoggerAdapter<RoutingMessagePublisher>)_logger.Object);
+    }
+
+    // Test message types
+    private record TestMessage
+    {
+        public Guid Id { get; init; }
+    }
+
+    private record UnknownMessage
+    {
+        public string Data { get; init; } = string.Empty;
+    }
+}

--- a/tests/Api.Project.Template.Tests.Unit/Infrastructure/Messaging/ServiceBus/ServiceBusBrokerAdapterTests.cs
+++ b/tests/Api.Project.Template.Tests.Unit/Infrastructure/Messaging/ServiceBus/ServiceBusBrokerAdapterTests.cs
@@ -1,0 +1,106 @@
+using Api.Project.Template.Application.Abstractions.Logging;
+using Api.Project.Template.Application.Messaging;
+using Api.Project.Template.Infrastructure.Messaging;
+using Api.Project.Template.Infrastructure.Messaging.Abstractions;
+using Api.Project.Template.Infrastructure.Messaging.ServiceBus;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Api.Project.Template.Tests.Unit.Infrastructure.Messaging.ServiceBus;
+
+public class ServiceBusBrokerAdapterTests
+{
+    private readonly Mock<ILoggerAdapter<ServiceBusBrokerAdapter>> _logger = new();
+
+    [Fact]
+    public void Constructor_CreatesInstance()
+    {
+        // Act
+        var adapter = new ServiceBusBrokerAdapter(_logger.Object);
+
+        // Assert
+        Assert.NotNull(adapter);
+    }
+
+    [Fact]
+    public void Constructor_ImplementsIMessageBrokerAdapter()
+    {
+        // Act
+        var adapter = new ServiceBusBrokerAdapter(_logger.Object);
+
+        // Assert
+        Assert.IsAssignableFrom<IMessageBrokerAdapter>(adapter);
+    }
+
+    [Fact]
+    public void Constructor_ImplementsIAsyncDisposable()
+    {
+        // Act
+        var adapter = new ServiceBusBrokerAdapter(_logger.Object);
+        // Assert
+        Assert.IsAssignableFrom<IAsyncDisposable>(adapter);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_CanBeCalledWithoutConnect()
+    {
+        // Arrange
+        var adapter = new ServiceBusBrokerAdapter(_logger.Object);
+
+        // Act & Assert - should not throw
+        await adapter.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task DisconnectAsync_CanBeCalledWithoutConnect()
+    {
+        // Arrange
+        var adapter = new ServiceBusBrokerAdapter(_logger.Object);
+
+        // Act & Assert - should not throw
+        await adapter.DisconnectAsync();
+    }
+
+    [Fact]
+    public async Task SubscribeAsync_WithoutConnect_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var adapter = new ServiceBusBrokerAdapter(_logger.Object);
+
+        Task<MessageProcessingResult> Handler(TestMessage msg, MessageContext ctx)
+        {
+            return Task.FromResult(MessageProcessingResult.Succeeded());
+        }
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await adapter.SubscribeAsync<TestMessage>(Handler, CancellationToken.None);
+        });
+    }
+
+    [Fact]
+    public void MessageBrokerConfig_SupportsProviderSpecificSettings()
+    {
+        // Arrange
+        var config = new MessageBrokerConfig
+        {
+            ConnectionString = "Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=test",
+            Queue = "test-queue",
+            ProviderSpecific = new Dictionary<string, string>
+            {
+                ["SubscriptionName"] = "test-subscription"
+            }
+        };
+
+        // Assert
+        Assert.Equal("test-subscription", config.ProviderSpecific["SubscriptionName"]);
+    }
+
+    // Test message type
+    private class TestMessage
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+}

--- a/tests/Api.Project.Template.Tests.Unit/Infrastructure/Messaging/ServiceBus/ServiceBusMessagePublisherTests.cs
+++ b/tests/Api.Project.Template.Tests.Unit/Infrastructure/Messaging/ServiceBus/ServiceBusMessagePublisherTests.cs
@@ -1,0 +1,65 @@
+using Api.Project.Template.Application.Abstractions.Logging;
+using Api.Project.Template.Infrastructure.Messaging.Abstractions;
+using Api.Project.Template.Infrastructure.Messaging.ServiceBus;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Api.Project.Template.Tests.Unit.Infrastructure.Messaging.ServiceBus;
+
+public class ServiceBusMessagePublisherTests
+{
+    private readonly Mock<ILoggerAdapter<ServiceBusMessagePublisher>> _logger = new();
+
+    [Fact]
+    public void Constructor_WithValidConfiguration_Succeeds()
+    {
+        // Arrange
+        var config = CreateTestConfiguration();
+
+        // Act
+        var publisher = new ServiceBusMessagePublisher(config, _logger.Object);
+
+        // Assert
+        Assert.NotNull(publisher);
+    }
+
+    [Fact]
+    public void Constructor_WithMissingConnectionString_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var config = new ConfigurationBuilder().Build();
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() =>
+            new ServiceBusMessagePublisher(config, _logger.Object));
+    }
+
+    [Fact]
+    public async Task PublishAsync_NullMessage_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var config = CreateTestConfiguration();
+        var publisher = new ServiceBusMessagePublisher(config, _logger.Object);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            publisher.PublishAsync<TestMessage>(null!, cancellationToken: TestContext.Current.CancellationToken));
+    }
+
+    private static IConfiguration CreateTestConfiguration()
+    {
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:servicebus"] = "Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=test"
+            })
+            .Build();
+    }
+
+    private record TestMessage
+    {
+        public Guid Id { get; init; }
+        public string Content { get; init; } = string.Empty;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a provider-switchable message bus abstraction supporting RabbitMQ and Azure Service Bus, configured via `MessagingProvider` (mirrors the existing `DatabaseProvider` pattern)
- Adds a `WeatherForecastRequestedEvent` domain event published via MediatR notification when weather forecasts are queried, handled by `WeatherForecastRequestedEventHandler` which forwards to the message bus
- Adds a new `Api.Project.Template.Worker` .NET Worker Service with `WeatherRequestProcessor` that consumes `WeatherRequested` messages from the broker
- Wires RabbitMQ and Azure Service Bus resources into Aspire AppHost, both referencing the API and Worker projects

## Test plan

- [ ] Set `MessagingProvider` to `RabbitMq` in AppHost `appsettings.json` and run via Aspire — verify RabbitMQ container starts and messages flow from API to Worker
- [ ] Set `MessagingProvider` to `ServiceBus` in AppHost `appsettings.json` — verify Azure Service Bus resource is provisioned and wired correctly
- [ ] Set `MessagingProvider` to `None` — verify API and Worker start without any messaging dependencies
- [ ] Hit the weather forecast endpoint and confirm `WeatherRequestProcessor` logs the received message in the Worker
- [ ] Run unit tests